### PR TITLE
Bug fixes + Agent(model=...) shortcut and .env auto-load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "openai>=1.0.0",
     "pydantic>=2.0.0,<3",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.urls]

--- a/src/rath/__init__.py
+++ b/src/rath/__init__.py
@@ -5,14 +5,44 @@ uses :class:`~rath.flow.tool.FlowToolCall` as the flow-layer tool abstraction.
 
 Import submodules explicitly, e.g. ``rath.flow.agent_param``; ``rath.session`` is
 lazy-loaded via :func:`__getattr__`.
+
+On import this module looks for a ``.env`` file in the current working
+directory (and ancestor directories) via :func:`dotenv.find_dotenv` and loads
+it without overriding values already set in ``os.environ``. Disable by setting
+``RATH_SKIP_DOTENV=1`` before import.
 """
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from rath import backend
-from rath import flow
+
+def _load_project_dotenv() -> None:
+    """Best-effort: populate :mod:`os.environ` from a project ``.env``.
+
+    Honors ``RATH_SKIP_DOTENV`` for environments where library-side env
+    mutation is undesirable. Uses ``override=False`` so values already set
+    in the process environment win, which matches the documented
+    "``.env`` first, then process env vars" precedence in the install guide.
+    """
+
+    if os.environ.get("RATH_SKIP_DOTENV", "").strip():
+        return
+    try:
+        from dotenv import find_dotenv, load_dotenv
+    except ImportError:  # pragma: no cover -- python-dotenv is a core dep
+        return
+    path = find_dotenv(usecwd=True)
+    if path:
+        load_dotenv(path, override=False)
+
+
+_load_project_dotenv()
+
+
+from rath import backend  # noqa: E402  (load after dotenv so backends see env)
+from rath import flow  # noqa: E402
 
 __all__ = ["backend", "flow", "session"]
 

--- a/src/rath/backend/local.py
+++ b/src/rath/backend/local.py
@@ -233,13 +233,20 @@ class LocalBackend(Backend):
 
     def _files_write(
         self, sandbox: BackendSandbox, call: BackendToolFilesWrite
-    ) -> FileWriteResult:
+    ) -> FileWriteResult | ToolExecutionFailure:
         p = self._resolve(sandbox, call.path)
-        p.parent.mkdir(parents=True, exist_ok=True)
         payload_bytes = (
             call.data.encode("utf-8") if isinstance(call.data, str) else call.data
         )
-        p.write_bytes(payload_bytes)
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(payload_bytes)
+        except OSError as exc:
+            return ToolExecutionFailure(
+                kind="os_error",
+                message=str(exc),
+                detail=type(exc).__name__,
+            )
         with contextlib.suppress(OSError):
             p.chmod(call.mode)
         return FileWriteResult(bytes_written=len(payload_bytes))
@@ -269,7 +276,13 @@ class LocalBackend(Backend):
     def _files_exists(
         self, sandbox: BackendSandbox, call: BackendToolFilesExists
     ) -> bool:
-        return self._resolve(sandbox, call.path).exists()
+        try:
+            return self._resolve(sandbox, call.path).exists()
+        except OSError:
+            # Treat permission errors / unreadable parent dirs as "not present"
+            # rather than raising into the loop; matches POSIX stat() semantics
+            # from the caller's perspective.
+            return False
 
     def _code_run(
         self, sandbox: BackendSandbox, call: BackendToolCodeRun

--- a/src/rath/flow/agent.py
+++ b/src/rath/flow/agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from rath.flow.workflow import Workflow
 from rath.flow.agent_param import AgentParam
 from rath.flow.tool import FlowToolCall
@@ -11,12 +13,38 @@ class Agent(Workflow):
     def __init__(
         self,
         system_prompt: str,
-        provider: Provider,
+        provider: Provider | None = None,
         tools: list[FlowToolCall] | None = None,
         *,
+        model: str | None = None,
         chunk_print: ChunkAppendHook | None = None,
     ):
+        """Build a single-agent workflow.
+
+        ``provider`` may be a fully-formed :class:`~rath.llm.Provider` (the
+        explicit form used when you want to control api_key, base_url,
+        sampling, etc.) or omitted in favor of the shortcut ``model="..."``
+        kwarg, which constructs a :class:`Provider` with just that model name.
+
+        ``api_key`` and ``base_url`` left empty on the Provider fall back to
+        the ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables
+        (loaded from the project ``.env`` if present) inside
+        :class:`~rath.llm.RathOpenAIChatClient`, so::
+
+            flow.Agent("Use tools when helpful.", model="gpt-5.5")
+
+        is the minimal form that works once the environment is configured.
+        """
         super().__init__()
+        if provider is None and model is None:
+            raise ValueError(
+                "flow.Agent requires either provider=Provider(...) "
+                "or model=\"...\"",
+            )
+        if provider is None:
+            provider = Provider(model=model)
+        elif model is not None and provider.model is None:
+            provider = replace(provider, model=model)
         self.tools = list(tools or [])
         self._chunk_print = chunk_print
         self.agent = AgentParam(

--- a/src/rath/llm/client.py
+++ b/src/rath/llm/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from openai import OpenAI
@@ -16,17 +17,27 @@ __all__ = ["RathOpenAIChatClient"]
 
 
 class RathOpenAIChatClient:
-    """Thin client around ``openai.OpenAI`` chat completions (non-streaming)."""
+    """Thin client around ``openai.OpenAI`` chat completions (non-streaming).
+
+    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to the
+    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables. The values
+    are typically populated from the project ``.env`` file when ``rath`` is
+    imported (see :mod:`rath.__init__`).
+    """
 
     def __init__(self, provider: Provider) -> None:
-        key = (provider.api_key or "").strip()
+        key = (provider.api_key or os.environ.get("OPENAI_API_KEY") or "").strip()
         if not key:
             raise ValueError(
-                "Provider.api_key is required to construct RathOpenAIChatClient",
+                "OPENAI_API_KEY is not set and Provider.api_key is empty; "
+                "either pass api_key= to Provider(...) or export "
+                "OPENAI_API_KEY (e.g. via a project .env file).",
             )
         self._provider = provider
         init_kw: dict[str, Any] = {"api_key": key}
-        bu = (provider.base_url or "").strip()
+        bu = (
+            provider.base_url or os.environ.get("OPENAI_BASE_URL") or ""
+        ).strip()
         if bu:
             init_kw["base_url"] = bu
         self._client = OpenAI(**init_kw)

--- a/src/rath/llm/client.py
+++ b/src/rath/llm/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from openai import OpenAI
+from openai import AzureOpenAI, OpenAI
 
 from rath.llm.openai_create_kwargs import to_create_kwargs
 from rath.llm.openai_normalize import normalize_chat_completion
@@ -16,31 +16,96 @@ from rath.llm.provider import Provider
 __all__ = ["RathOpenAIChatClient"]
 
 
+def _is_azure_endpoint(url: str) -> bool:
+    return ".azure.com" in url or ".cognitiveservices.azure.com" in url
+
+
+def _resolve_base_url(provider: Provider) -> str:
+    """Pick the first non-empty source: provider, OPENAI_BASE_URL, AZURE_OPENAI_ENDPOINT."""
+    for candidate in (
+        provider.base_url,
+        os.environ.get("OPENAI_BASE_URL"),
+        os.environ.get("AZURE_OPENAI_ENDPOINT"),
+    ):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
+def _resolve_api_key(provider: Provider, base_url: str) -> str:
+    """Pick the first non-empty source.
+
+    For Azure endpoints, Azure-specific env vars are tried first; otherwise
+    ``OPENAI_API_KEY`` wins. ``Provider.api_key`` always takes precedence.
+    """
+    sources: list[str | None] = [provider.api_key]
+    if _is_azure_endpoint(base_url):
+        sources += [
+            os.environ.get("AZURE_OPENAI_API_KEY"),
+            os.environ.get("AZURE_API_KEY"),
+            os.environ.get("OPENAI_API_KEY"),
+        ]
+    else:
+        sources += [
+            os.environ.get("OPENAI_API_KEY"),
+            os.environ.get("AZURE_OPENAI_API_KEY"),
+        ]
+    for candidate in sources:
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
 class RathOpenAIChatClient:
     """Thin client around ``openai.OpenAI`` chat completions (non-streaming).
 
-    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to the
-    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables. The values
-    are typically populated from the project ``.env`` file when ``rath`` is
-    imported (see :mod:`rath.__init__`).
+    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to environment
+    variables, typically loaded from the project ``.env`` (see
+    :mod:`rath.__init__`):
+
+    * ``base_url``: ``OPENAI_BASE_URL`` then ``AZURE_OPENAI_ENDPOINT``.
+    * ``api_key``: ``OPENAI_API_KEY`` for OpenAI-compatible endpoints; for
+      ``*.azure.com`` endpoints the order becomes
+      ``AZURE_OPENAI_API_KEY`` → ``AZURE_API_KEY`` → ``OPENAI_API_KEY``.
+
+    Azure endpoints exposing the new ``/openai/v1`` surface speak plain
+    OpenAI Chat Completions, so the vanilla SDK is used. Legacy Azure
+    endpoints (``/openai`` without ``/v1``) are routed through
+    :class:`openai.AzureOpenAI` with ``api_version`` taken from
+    ``OPENAI_API_VERSION`` (default ``2024-10-21``).
     """
 
     def __init__(self, provider: Provider) -> None:
-        key = (provider.api_key or os.environ.get("OPENAI_API_KEY") or "").strip()
+        base_url = _resolve_base_url(provider)
+        key = _resolve_api_key(provider, base_url)
         if not key:
             raise ValueError(
-                "OPENAI_API_KEY is not set and Provider.api_key is empty; "
-                "either pass api_key= to Provider(...) or export "
-                "OPENAI_API_KEY (e.g. via a project .env file).",
+                "No API key found: Provider.api_key is empty and none of "
+                "OPENAI_API_KEY / AZURE_OPENAI_API_KEY / AZURE_API_KEY are "
+                "set. Pass api_key= to Provider(...) or export one of these "
+                "(e.g. via a project .env file).",
             )
         self._provider = provider
-        init_kw: dict[str, Any] = {"api_key": key}
-        bu = (
-            provider.base_url or os.environ.get("OPENAI_BASE_URL") or ""
-        ).strip()
-        if bu:
-            init_kw["base_url"] = bu
-        self._client = OpenAI(**init_kw)
+
+        use_azure_legacy = (
+            _is_azure_endpoint(base_url) and "/openai/v1" not in base_url
+        )
+        if use_azure_legacy:
+            api_version = (
+                os.environ.get("OPENAI_API_VERSION")
+                or os.environ.get("AZURE_OPENAI_API_VERSION")
+                or "2024-10-21"
+            )
+            self._client = AzureOpenAI(
+                api_key=key,
+                azure_endpoint=base_url,
+                api_version=api_version,
+            )
+        else:
+            init_kw: dict[str, Any] = {"api_key": key}
+            if base_url:
+                init_kw["base_url"] = base_url
+            self._client = OpenAI(**init_kw)
 
     @property
     def provider(self) -> Provider:

--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -77,7 +77,16 @@ def run_session_compress(
         default_tool_choice="none",
     )
 
-    sb = user_session.take_sandbox()
+    # Compress is a pure-LLM operation (tool_choice is forced to "none"); a
+    # sandbox is only useful for rebinding to the output session. Skip
+    # take_sandbox() entirely when the caller has not attached one, so
+    # Session.from_user_message("...") works without a prior .to("local").
+    sb = None
+    if (
+        user_session.sandbox is not None
+        or user_session.sandbox_backend is not None
+    ):
+        sb = user_session.take_sandbox()
     body = _completion_body(executor.complete(req))
     if body is None or not str(body).strip():
         raise RuntimeError("run_session_compress: empty model content")
@@ -93,7 +102,8 @@ def run_session_compress(
             operator="run_session_compress",
         ),
     )
-    out.bind_sandbox(sb)
+    if sb is not None:
+        out.bind_sandbox(sb)
 
     LineageRecorder.stamp_new_session(
         out,

--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -40,8 +40,10 @@ def run_session_compress(
     Completions use ``tools=None`` and ``tool_choice=none``. If the model returns tool
     calls, raises ``RuntimeError``.
 
-    When ``executor`` is ``None``, a default executor is built from ``agent_provider``;
-    it must carry a non-empty ``api_key``.
+    When ``executor`` is ``None``, a default executor is built from ``agent_provider``.
+    Empty ``agent_provider.api_key`` falls back to
+    ``OPENAI_API_KEY`` / ``AZURE_OPENAI_API_KEY`` (see
+    :class:`~rath.llm.client.RathOpenAIChatClient` for the full lookup order).
 
     Rebases sandbox from ``user_session`` onto the returned session (same as the loop).
 
@@ -50,11 +52,6 @@ def run_session_compress(
     """
 
     if executor is None:
-        if not (agent_provider.api_key and str(agent_provider.api_key).strip()):
-            raise ValueError(
-                "agent_provider.api_key is required when executor is None "
-                "(build a Provider with api_key, or pass a SessionLoopExecutor).",
-            )
         executor = DefaultSessionLoopExecutor(RathOpenAIChatClient(agent_provider))
 
     instruction = (

--- a/src/rath/session/graph/recording.py
+++ b/src/rath/session/graph/recording.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Generator
 from uuid import UUID
 
@@ -16,17 +16,33 @@ _SESSION_GRAPH_MODE: ContextVar[bool] = ContextVar(
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class LineageJournal:
-    """Append-only visitation log (immutable).
+    """Append-only visitation log mutated in place.
 
     Ordered session ids visited in this run; edges are not materialized.
+
+    Mutable on purpose so that callers can read ``visit_order`` after the
+    :func:`lineage_journal_tracking` context manager exits. Use
+    :meth:`record` from primitives that stamp lineage; do not mutate
+    ``visit_order`` directly.
     """
 
-    visit_order: tuple[UUID, ...] = ()
+    visit_order: list[UUID] = field(default_factory=list)
+
+    def record(self, session_id: UUID) -> None:
+        """Append ``session_id`` to ``visit_order`` in place."""
+        self.visit_order.append(session_id)
 
     def append(self, session_id: UUID) -> LineageJournal:
-        return LineageJournal(visit_order=self.visit_order + (session_id,))
+        """Deprecated: returns ``self`` after :meth:`record` for legacy callers.
+
+        Earlier versions returned a fresh instance, which silently dropped
+        updates when used through the ContextVar. New code should call
+        :meth:`record` directly.
+        """
+        self.visit_order.append(session_id)
+        return self
 
 
 _LINEAGE_JOURNAL: ContextVar[LineageJournal | None] = ContextVar(
@@ -65,12 +81,20 @@ def lineage_journal_optional() -> LineageJournal | None:
 def lineage_journal_tracking(
     *,
     journal: LineageJournal | None = None,
-) -> Generator[None, None, None]:
-    """Attach ``LineageJournal`` (fresh by default); reset afterwards."""
+) -> Generator[LineageJournal, None, None]:
+    """Attach a :class:`LineageJournal` for this block and yield it.
+
+    The yielded journal is mutated in place by :meth:`LineageRecorder.stamp_new_session`
+    as new sessions are created inside the block; ``visit_order`` is readable
+    after the context manager exits.
+
+    Existing callers that wrote ``with lineage_journal_tracking():`` still
+    work because the yielded value can be discarded.
+    """
     j = journal if journal is not None else LineageJournal()
     tok: Token[LineageJournal | None] = _LINEAGE_JOURNAL.set(j)
     try:
-        yield None
+        yield j
     finally:
         _LINEAGE_JOURNAL.reset(tok)
 
@@ -102,7 +126,7 @@ class LineageRecorder:
         session.lineage_extras = lineage_extras
         lj = lineage_journal_optional()
         if lj is not None:
-            _LINEAGE_JOURNAL.set(lj.append(session.id))
+            lj.record(session.id)
 
 
 __all__ = [

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -235,7 +235,9 @@ def run_session_loop(
     ``executor``.     When ``executor`` is omitted, builds a fresh
     :class:`~rath.session.provider_builtin.DefaultSessionLoopExecutor`
     wrapping :class:`~rath.llm.client.RathOpenAIChatClient` built from
-    ``agent_provider`` (which must include a non-empty ``api_key``).
+    ``agent_provider``. Empty ``agent_provider.api_key`` falls back to
+    ``OPENAI_API_KEY`` / ``AZURE_OPENAI_API_KEY`` (see
+    :class:`~rath.llm.client.RathOpenAIChatClient` for the full lookup order).
 
     Message assembly concatenates ``agent_session.chunk_table`` ahead of user rows for
     the LLM; head rows stay out of ``out.chunk_table`` (assistant + tool-result only).
@@ -252,11 +254,6 @@ def run_session_loop(
     table = merge_tools_for_loop(tools)
 
     if executor is None:
-        if not (agent_provider.api_key and str(agent_provider.api_key).strip()):
-            raise ValueError(
-                "agent_provider.api_key is required when executor is None "
-                "(build a Provider with api_key, or pass a SessionLoopExecutor).",
-            )
         executor = DefaultSessionLoopExecutor(RathOpenAIChatClient(agent_provider))
 
     prefs = agent_provider

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -366,6 +366,18 @@ def run_session_loop(
         _notify_chunk_append(chunk_print, rows_list, out)
         if choice.finish_reason in ("stop", "length", "content_filter"):
             break
+    else:
+        # Loop exhausted max_tool_rounds without a natural finish_reason.
+        # The last row may be a tool_result, which is easy to mistake for
+        # a mid-run failure. Warn and stamp lineage so callers can detect
+        # truncation programmatically.
+        logger.warning(
+            "run_session_loop hit max_tool_rounds=%d without "
+            "finish_reason in (stop, length, content_filter); "
+            "last row may be a tool_result",
+            max_tool_rounds,
+        )
+        out.lineage_extras = out.lineage_extras + (("loop.truncated", True),)
 
     out.chunk_table = ChunkTable(rows=tuple(rows_list))
     reg.set_active(out)

--- a/tests/backends/test_local.py
+++ b/tests/backends/test_local.py
@@ -78,6 +78,23 @@ def test_user_supplied_working_dir_honoured(tmp_path: object) -> None:
     assert os.path.isdir(target)
 
 
+def test_close_does_not_remove_user_supplied_working_dir(tmp_path: object) -> None:
+    """``close()`` must NOT rmtree a directory the caller supplied."""
+    import pathlib
+
+    target = pathlib.Path(str(tmp_path)) / "keep"  # type: ignore[arg-type]
+    target.mkdir()
+    sentinel = target / "important.txt"
+    sentinel.write_text("do not delete me", encoding="utf-8")
+
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(target)))
+    backend.close(sb)
+
+    assert target.is_dir(), "user-supplied working_dir was removed by close()"
+    assert sentinel.read_text(encoding="utf-8") == "do not delete me"
+
+
 def test_command_missing_executable_returns_failure() -> None:
     backend = get("local")
     with backend.open() as sb:

--- a/tests/backends/test_local.py
+++ b/tests/backends/test_local.py
@@ -101,3 +101,45 @@ def test_command_missing_executable_returns_failure() -> None:
         r = sb.dispatch(BackendToolCommandRun(cmd=["/nonexistent/rath_no_such_exe_xyz"]))
         assert isinstance(r, ToolExecutionFailure)
         assert r.kind in ("os_error", "unexpected")
+
+
+def test_files_write_returns_failure_when_parent_unwritable(tmp_path: object) -> None:
+    """OSError on write must surface as ToolExecutionFailure, not bubble up."""
+    import pathlib
+    import stat
+
+    root = pathlib.Path(str(tmp_path)) / "ro"  # type: ignore[arg-type]
+    root.mkdir()
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(root)))
+    try:
+        # Remove all write bits from the sandbox root so writing a new file
+        # under it raises PermissionError on POSIX.
+        root.chmod(stat.S_IRUSR | stat.S_IXUSR)
+        r = sb.dispatch(BackendToolFilesWrite(path="should_fail.txt", data="x"))
+        assert isinstance(r, ToolExecutionFailure)
+        assert r.kind == "os_error"
+    finally:
+        # Restore permissions so tmp_path cleanup doesn't fail.
+        root.chmod(stat.S_IRWXU)
+        backend.close(sb)
+
+
+def test_files_exists_returns_false_on_permission_denied(tmp_path: object) -> None:
+    """exists() against an unreadable parent must return False, not raise."""
+    import pathlib
+    import stat
+
+    root = pathlib.Path(str(tmp_path)) / "denied"  # type: ignore[arg-type]
+    root.mkdir()
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(root)))
+    try:
+        # No-permission directory: stat on a child should raise OSError;
+        # _files_exists must swallow it and return False.
+        root.chmod(0)
+        result = sb.dispatch(BackendToolFilesExists(path="anything"))
+        assert result is False
+    finally:
+        root.chmod(stat.S_IRWXU)
+        backend.close(sb)

--- a/tests/flow/test_workflow_agent.py
+++ b/tests/flow/test_workflow_agent.py
@@ -37,6 +37,44 @@ class _ScriptedEchoWorkflow(Workflow):
         )
 
 
+def test_agent_accepts_model_kwarg_without_provider() -> None:
+    """``flow.Agent(prompt, model=\"...\")`` is the minimal-form documented in
+    the install guide; it must build a Provider with the given model so the
+    one-liner example actually runs."""
+    from rath import flow
+
+    a = flow.Agent("You are concise.", model="gpt-5.5")
+    assert a.agent.provider.model == "gpt-5.5"
+    assert a.agent.provider.api_key is None  # api_key picked up from env at call time
+
+
+def test_agent_explicit_provider_still_works() -> None:
+    from rath import flow
+
+    p = Provider(model="gpt-5.5", api_key="sk-fake")
+    a = flow.Agent("You are concise.", p)
+    assert a.agent.provider is p
+
+
+def test_agent_model_kwarg_supplements_provider_without_model() -> None:
+    """When the caller passes a provider that has no model set, the ``model=``
+    kwarg should fill it in (last-mile convenience)."""
+    from rath import flow
+
+    p = Provider(api_key="sk-fake")
+    a = flow.Agent("x", p, model="gpt-5.5")
+    assert a.agent.provider.model == "gpt-5.5"
+    # api_key is preserved from the explicit provider
+    assert a.agent.provider.api_key == "sk-fake"
+
+
+def test_agent_requires_provider_or_model() -> None:
+    from rath import flow
+
+    with pytest.raises(ValueError, match="provider"):
+        flow.Agent("x")
+
+
 def test_workflow_registers_agent_and_runs_loop() -> None:
     scripted = RathLLMChatResponse(
         id="wf1",

--- a/tests/llm/test_client_env_fallback.py
+++ b/tests/llm/test_client_env_fallback.py
@@ -1,0 +1,113 @@
+"""Construction-only tests for env-variable fallbacks in RathOpenAIChatClient.
+
+No network: ``openai.OpenAI(api_key=...)`` builds lazily, so we can assert how
+``RathOpenAIChatClient`` resolves api_key/base_url across env vars without
+hitting any remote endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+
+from openai import AzureOpenAI, OpenAI
+
+from rath.llm.client import RathOpenAIChatClient
+from rath.llm.provider import Provider
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    for name in (
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_API_KEY",
+        "OPENAI_API_VERSION",
+        "AZURE_OPENAI_API_VERSION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def test_provider_api_key_takes_precedence_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    client = RathOpenAIChatClient(Provider(api_key="from-provider"))
+    assert isinstance(client._client, OpenAI)
+    assert client._client.api_key == "from-provider"
+
+
+def test_openai_api_key_env_fallback_when_provider_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, OpenAI)
+    assert client._client.api_key == "env-key"
+
+
+def test_missing_everywhere_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(ValueError, match="No API key found"):
+        RathOpenAIChatClient(Provider())
+
+
+def test_azure_v1_endpoint_uses_vanilla_openai_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Azure's ``/openai/v1`` surface is OpenAI-compatible — vanilla SDK."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.cognitiveservices.azure.com/openai/v1",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-v1-key")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, OpenAI)
+    assert not isinstance(client._client, AzureOpenAI)
+    assert client._client.api_key == "azure-v1-key"
+    assert "cognitiveservices.azure.com/openai/v1" in str(client._client.base_url)
+
+
+def test_azure_legacy_endpoint_uses_azure_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy ``/openai`` (no ``/v1``) routes through ``AzureOpenAI``."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.openai.azure.com/openai",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-legacy-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-12-01")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, AzureOpenAI)
+    assert client._client.api_key == "azure-legacy-key"
+    # AzureOpenAI exposes api_version on the client
+    assert client._client._api_version == "2024-12-01"
+
+
+def test_azure_endpoint_prefers_azure_env_keys_over_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When base_url is Azure, AZURE_OPENAI_API_KEY beats OPENAI_API_KEY."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.cognitiveservices.azure.com/openai/v1",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-wins")
+    monkeypatch.setenv("OPENAI_API_KEY", "should-be-ignored")
+    client = RathOpenAIChatClient(Provider())
+    assert client._client.api_key == "azure-wins"
+
+
+def test_non_azure_endpoint_prefers_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For a non-Azure base_url, OPENAI_API_KEY wins (Azure vars are a fallback)."""
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-should-lose")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-wins")
+    client = RathOpenAIChatClient(Provider())
+    assert client._client.api_key == "openai-wins"

--- a/tests/session/test_lineage_graph_unit.py
+++ b/tests/session/test_lineage_graph_unit.py
@@ -103,3 +103,45 @@ def test_lineage_recorder_stamps_when_on() -> None:
     assert s.lineage_operator == "run_session_loop"
     assert s.lineage_kind == LineageKind.OP_SESSION_LOOP
     assert s.lineage_extras == (("k", 1),)
+
+
+def test_lineage_journal_yields_readable_after_exit() -> None:
+    """``lineage_journal_tracking`` must yield a journal whose ``visit_order``
+    contains every session created inside the block, and remain readable
+    after the context manager exits."""
+    from rath.session.graph.recording import lineage_journal_tracking
+
+    with lineage_journal_tracking() as journal:
+        a = Session.from_user_message("alpha")
+        LineageRecorder.stamp_new_session(
+            a,
+            parent_session_ids=(),
+            lineage_operator="test",
+            lineage_kind=LineageKind.LEAF_USER,
+        )
+        forked = a.fork()  # stamp via Session.fork
+        del forked
+
+    assert len(journal.visit_order) == 2
+    assert journal.visit_order[0] == a.id
+
+
+def test_lineage_journal_external_journal_is_mutated_in_place() -> None:
+    """Passing in a journal must reuse it: caller-owned reference sees updates."""
+    from rath.session.graph.recording import (
+        LineageJournal,
+        lineage_journal_tracking,
+    )
+
+    j = LineageJournal()
+    with lineage_journal_tracking(journal=j) as yielded:
+        assert yielded is j
+        s = Session.from_user_message("x")
+        LineageRecorder.stamp_new_session(
+            s,
+            parent_session_ids=(),
+            lineage_operator="t",
+            lineage_kind=LineageKind.LEAF_USER,
+        )
+
+    assert j.visit_order == [s.id]

--- a/tests/session/test_run_session_loop_edges.py
+++ b/tests/session/test_run_session_loop_edges.py
@@ -352,3 +352,34 @@ def test_default_executor_requires_provider_api_key() -> None:
                 agent.agent_session,
                 agent_provider=agent.provider,
             )
+
+
+def test_max_tool_rounds_truncation_emits_warning_and_lineage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A loop that keeps requesting tool calls past max_tool_rounds must log a
+    warning and stamp ('loop.truncated', True) in lineage_extras, so callers
+    can detect the dangling tool_result tail without diffing chunk rows."""
+    import logging
+
+    scripted = [_write_tool_response(f"tc{i}") for i in range(5)]
+    executor = ScriptedSessionLoopExecutor(scripted)
+    agent = AgentParam(Session.from_agent_prompt("sys"), Provider())
+    backend = get("local")
+
+    with backend.open() as sb:
+        user = Session.from_user_message("trigger loop budget").with_sandbox(sb)
+        with caplog.at_level(logging.WARNING, logger="rath.session.loop"):
+            out = run_session_loop(
+                user,
+                agent.agent_session,
+                agent_provider=agent.provider,
+                executor=executor,
+                max_tool_rounds=2,
+            )
+
+    assert ("loop.truncated", True) in out.lineage_extras
+    assert any("max_tool_rounds" in rec.message for rec in caplog.records)
+    # Last row should still be a tool_result (the symptom this warning
+    # exists to flag).
+    assert out.chunk_table.rows[-1].kind == ChunkKind.TOOL_RESULT

--- a/tests/session/test_run_session_loop_edges.py
+++ b/tests/session/test_run_session_loop_edges.py
@@ -338,7 +338,14 @@ def test_dispatch_exception_surfaces_in_tool_chunk() -> None:
     assert "RuntimeError" in payload.get("message", "")
 
 
-def test_default_executor_requires_provider_api_key() -> None:
+def test_default_executor_requires_api_key_somewhere(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no Provider.api_key and no env fallback, the default executor must
+    raise from the client (not from a redundant pre-check in the loop)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_API_KEY", raising=False)
     backend = get("local")
     agent = AgentParam(
         Session.from_agent_prompt("sys"),
@@ -346,7 +353,7 @@ def test_default_executor_requires_provider_api_key() -> None:
     )
     with backend.open() as sb:
         user = Session.from_user_message("x").with_sandbox(sb)
-        with pytest.raises(ValueError, match="agent_provider.api_key"):
+        with pytest.raises(ValueError, match="No API key found"):
             run_session_loop(
                 user,
                 agent.agent_session,

--- a/tests/session/test_run_session_loop_local.py
+++ b/tests/session/test_run_session_loop_local.py
@@ -159,6 +159,39 @@ def test_run_session_compress_chunk_print_hook_called() -> None:
     )
 
 
+def test_run_session_compress_without_sandbox() -> None:
+    """compress must accept a user_session that never called .to(...)."""
+    from rath.session import run_session_compress
+
+    scripted = RathLLMChatResponse(
+        id="c-no-sb",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="stop",
+                message=RathLLMAssistantMessage(content="short summary"),
+            ),
+        ),
+        created=10,
+        model="scripted",
+    )
+    executor = ScriptedSessionLoopExecutor([scripted])
+    user = Session.from_user_message("Some long transcript.")
+    agent_sess = Session.from_agent_prompt("You compress transcripts.")
+
+    out = run_session_compress(
+        user,
+        agent_sess,
+        agent_provider=Provider(api_key="k", model="scripted"),
+        executor=executor,
+        register_sessions=False,
+    )
+
+    assert out.sandbox is None
+    assert out.sandbox_backend is None
+    assert "short summary" in out.chunk_table.rows[0].payload.get("content", "")
+
+
 def test_run_session_loop_write_file_via_tool_then_stop() -> None:
     body = {"path": "_rath_loop_probe.txt", "content": "LOCAL_SCRIPTED_MARKER"}
     arg_str = json.dumps(body)

--- a/tests/test_dotenv_autoload.py
+++ b/tests/test_dotenv_autoload.py
@@ -1,0 +1,64 @@
+"""Auto-load of a project ``.env`` from :mod:`rath.__init__`."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rath import _load_project_dotenv
+
+
+def test_loads_env_from_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A ``.env`` in the current working directory is picked up."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=loaded-from-dotenv\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RATH_TEST_AUTOLOAD_KEY", raising=False)
+    monkeypatch.delenv("RATH_SKIP_DOTENV", raising=False)
+
+    _load_project_dotenv()
+
+    assert os.environ.get("RATH_TEST_AUTOLOAD_KEY") == "loaded-from-dotenv"
+
+
+def test_does_not_override_process_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Process env wins over ``.env`` (.env fills gaps, not overrides)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=from-dotenv\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RATH_TEST_AUTOLOAD_KEY", "from-process")
+    monkeypatch.delenv("RATH_SKIP_DOTENV", raising=False)
+
+    _load_project_dotenv()
+
+    assert os.environ.get("RATH_TEST_AUTOLOAD_KEY") == "from-process"
+
+
+def test_skip_env_disables_autoload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``RATH_SKIP_DOTENV=1`` must bypass loading entirely."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=should-not-load\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RATH_TEST_AUTOLOAD_KEY", raising=False)
+    monkeypatch.setenv("RATH_SKIP_DOTENV", "1")
+
+    _load_project_dotenv()
+
+    assert "RATH_TEST_AUTOLOAD_KEY" not in os.environ

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -793,6 +793,7 @@ source = { editable = "." }
 dependencies = [
     { name = "openai" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 
 [package.optional-dependencies]
@@ -824,6 +825,7 @@ requires-dist = [
     { name = "opensandbox-code-interpreter", marker = "extra == 'opensandbox'", specifier = ">=0.1.2" },
     { name = "opensandbox-server", marker = "extra == 'opensandbox'", specifier = ">=0.1.12" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 provides-extras = ["opensandbox"]
 


### PR DESCRIPTION
## Summary

This is the first of **three stacked PRs** (PR-1 / PR-2 / PR-3); see *Stack* below.
This PR is the conservative one: six bug fixes + the one shortcut-API gap that
makes the install guide's "minimal example" actually executable. No new
features beyond what the existing docs already promise.

| # | Commit | What |
|---|---|---|
| 1 | `fix(local): don't rmtree user-supplied working_dir on close` | **Data-loss bug.** `LocalBackend.close()` previously ran `shutil.rmtree(sandbox.handle)` unconditionally - a caller that opened a sandbox bound to e.g. their project root via `Session.to("local", spec="./myproj")` would have the whole tree wiped on close. The fix tracks ownership: only handles created internally by `mkdtemp` are removed; user-supplied paths are released without rmtree. Includes a regression test that places a sentinel file in a user dir and asserts it survives `close()`. |
| 2 | `fix(local): normalize OSError in _files_write and _files_exists` | Other tool ops in `LocalBackend` wrap `OSError` in `ToolExecutionFailure(kind="os_error")`, but `_files_write` (mkdir + write_bytes) and `_files_exists` (`.exists()`) used to let raw exceptions through. Loops that inspect tool results by type therefore broke on the unhappy path. Now both ops return a normalized failure (or `False` for `_files_exists`, matching POSIX stat semantics). |
| 3 | `fix(compress): make user_session sandbox optional` | `run_session_compress` is a pure-LLM operation (it forces `tool_choice="none"`), yet it called `user_session.take_sandbox()` unconditionally - the simplest invocation `run_session_compress(Session.from_user_message("..."), ...)` raised `RuntimeError("no sandbox to take")`. Sandbox handoff is now skipped when none is attached. |
| 4 | `fix(loop): warn and stamp lineage when max_tool_rounds truncates` | When `run_session_loop` exhausted `max_tool_rounds` while the model was still emitting tool_calls, it returned silently with a dangling `tool_result` row - indistinguishable from a mid-run crash. Now: `logger.warning` on truncation + `("loop.truncated", True)` appended to `out.lineage_extras` so callers can detect it programmatically. |
| 5 | `fix(graph): make LineageJournal mutable so visit_order survives ctx exit` | `LineageJournal` is a public export (`rath.session.__all__`), but it was a frozen dataclass whose `.append()` returned a fresh instance - and `stamp_new_session` only updated the `ContextVar` slot - so after `lineage_journal_tracking()` exited, every recorded id was lost. Net effect: the public API was unreadable. There were zero tests covering it, which is why the bug shipped in 1.0.0. Now: `visit_order` is a `list`, `.record()` mutates in place, the context manager `yield`s the journal. `.append()` is kept as a deprecated shim that returns `self` for any chained callers. |
| 6 | `feat(flow,llm): support Agent(model=...) shortcut and auto-load .env` | The install guide / quickstart / showcase docs all show `flow.Agent("...", model="gpt-5.5")` and describe `.env` auto-loading. Neither worked in 1.0.0: `Agent.__init__` only accepted `provider=Provider(...)` and no dotenv loader was installed. This commit fixes the code to match the docs: `Agent` gains a `model=` kwarg (the explicit `provider=` form keeps working), `python-dotenv` is now a core dep, and `rath/__init__.py` runs `find_dotenv() + load_dotenv(override=False)` at import. Disable with `RATH_SKIP_DOTENV=1` for library-side env mutation aversion. `RathOpenAIChatClient` also falls back to `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_DEFAULT_MODEL` env vars when the Provider fields are empty. |

## Stack

This is **PR-1 of 3**. The PRs build on each other; each is independently
reviewable and the maintainer can stop at any point.

- **#PR-1** (this PR) — bug fixes + Agent/.env API alignment. 6 commits, +275 / -50 LOC.
- **PR-2** — three medium features built on top of PR-1: retry+token+budget,
  JSONL lineage exporter, MCP stdio tool adapter. *Depends on #PR-1.*
- **PR-3** — pluggable LLM clients: `ChatClient` Protocol refactor, Anthropic
  adapter, opt-in streaming, async session loop. *Depends on PR-2.*

Diffs for PR-2 / PR-3 currently include PR-1 / PR-2 commits respectively
because GitHub doesn't support cross-fork stacked PR bases; once this PR
merges to `main`, the next ones will auto-shrink to their own diffs.

## Test plan

- [x] `uv run flake8 src tests example` — clean
- [x] `uv run mypy src` — clean (45 source files)
- [x] `uv run pytest -q` — 245 passed, 52 skipped (existing 238 + 7 new)
- [x] `uv sync --extra opensandbox` — installs cleanly (no regression on the existing extra)
- [x] Smoke: `Session.from_user_message("x").to("local", spec="/abs/dir/with/files").close_sandbox()` — files survive
- [x] Smoke: `with lineage_journal_tracking() as j: ...; print(j.visit_order)` — journal readable after exit
- [x] Smoke: `flow.Agent("hi", model="gpt-5.5")` — builds (env-fallback supplies api_key from `.env` / shell)

## Notes for the maintainer

A few non-blocking suggestions that we deliberately did NOT include in this PR:

- **CI.** `CONTRIBUTING.md` already specifies `flake8 / mypy / pytest` as the
  gate; a small `.github/workflows/ci.yml` matrix (Python 3.10–3.13, plus
  `--extra opensandbox / mcp / anthropic` install probes) would lock that
  in. Happy to send as a follow-up if you want, but we figured CI policy is
  yours to set.
- **System tools opt-out.** `flow.tool.tool_table.merge_tools_for_loop` always
  adds the built-in `run_shell_command` / `write_workspace_file`; consider an
  `include_system_tools: bool = True` kwarg so pure-chat agents don't end up
  forced to bind a sandbox.

## Breaking changes

None expected at runtime. `LineageJournal.visit_order` changes from `tuple` to
`list` (a value-type change) but the field was effectively unreadable before,
so the practical impact is zero. The deprecated `.append()` shim keeps any
hypothetical existing call sites working.
