### PR TITLE
Retry + token/budget tracking + JSONL lineage exporter + MCP adapter

### DIFF
--- a/example/_demo_echo_server.py
+++ b/example/_demo_echo_server.py
@@ -1,0 +1,60 @@
+"""Tiny stdio MCP server used by ``example/mcp_tool_usage.py``.
+
+Exposes one ``echo`` tool. Not a serious deployment - the entire point is
+to give the bridge example something deterministic to talk to without
+external dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+
+server: Server = Server("rath-demo-echo")
+
+
+@server.list_tools()
+async def _list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="echo",
+            description="Echo the provided text back to the caller.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "Text to echo",
+                    },
+                },
+                "required": ["text"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    if name == "echo":
+        return [
+            TextContent(type="text", text=str(arguments.get("text", ""))),
+        ]
+    return [TextContent(type="text", text=f"unknown tool: {name}")]
+
+
+async def _main() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/example/lineage_export.py
+++ b/example/lineage_export.py
@@ -1,0 +1,57 @@
+"""Generate a small session lineage graph and dump it as JSONL.
+
+Run::
+
+    python example/lineage_export.py
+
+No LLM or sandbox required. The script forks and detaches a handful of
+sessions inside :func:`lineage_journal_tracking` and writes the resulting
+graph to ``lineage_demo.jsonl``. Inspect with ``jq`` for a quick
+sanity-check::
+
+    jq '.lineage_operator' lineage_demo.jsonl
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rath.session import Session
+from rath.session.graph import (
+    export_journal_jsonl,
+    export_jsonl_string,
+    lineage_journal_tracking,
+)
+from rath.session.manager import session_registry
+
+
+def main() -> None:
+    out_path = Path("lineage_demo.jsonl")
+    reg = session_registry()
+
+    # ``run_session_loop`` registers sessions automatically. Outside the loop,
+    # do it explicitly so the registry-driven exporter can resolve every id in
+    # ``journal.visit_order``.
+    with lineage_journal_tracking() as journal:
+        root = Session.from_user_message("Initial user message.")
+        reg.register(root)
+        # Two parallel forks off the root.
+        plan_branch = root.fork()
+        reg.register(plan_branch)
+        critique_branch = root.fork()
+        reg.register(critique_branch)
+        # A detached child off the plan branch (lineage_kind=OP_DETACH).
+        reg.register(plan_branch.detach())
+        # An extra fork to make the visit_order non-trivial.
+        reg.register(critique_branch.fork())
+
+    export_journal_jsonl(journal, out_path)
+    print(f"Wrote {len(journal.visit_order)} session rows to {out_path.resolve()}")
+
+    explicit = [root, plan_branch, critique_branch]
+    print("---explicit export (3 rows, not registry-driven)---")
+    print(export_jsonl_string(explicit), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/mcp_tool_usage.py
+++ b/example/mcp_tool_usage.py
@@ -1,0 +1,56 @@
+"""Wire an MCP stdio server's tools into a session loop.
+
+Install the extra::
+
+    pip install "openrath[mcp]"
+
+Then run::
+
+    python example/mcp_tool_usage.py
+
+This example launches a tiny in-process MCP server (``_demo_echo_server``) so
+no external setup is needed; replace the ``command`` argument with a real
+server such as ``["python", "-m", "mcp_server_filesystem"]`` for a useful
+deployment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rath.flow.tool.mcp_adapter import (
+    is_mcp_available,
+    mcp_tools_from_server,
+)
+
+
+_DEMO_SERVER = Path(__file__).parent / "_demo_echo_server.py"
+
+
+def main() -> None:
+    if not is_mcp_available():
+        print(
+            "mcp is not installed. Run: pip install 'openrath[mcp]'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tools = mcp_tools_from_server([sys.executable, str(_DEMO_SERVER)])
+    print(f"Discovered {len(tools)} MCP tool(s):")
+    for t in tools:
+        print(f"  - {t.name}: {t.description}")
+        print(f"    parameters keys: {list(t.parameters.keys())}")
+
+    # Use one of the tools through the FlowToolCall interface.
+    if tools:
+        echo = next((t for t in tools if t.name == "echo"), tools[0])
+        # The first arg (session) is unused by MCP tools; pass None-equivalent.
+        from rath.session import Session
+
+        result = echo(Session.from_user_message("dummy"), {"text": "hello from mcp"})
+        print("\nresult:", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "openai>=1.0.0",
     "pydantic>=2.0.0,<3",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ opensandbox = [
     "opensandbox-code-interpreter>=0.1.2",
     "opensandbox-server>=0.1.12",
 ]
+mcp = [
+    "mcp>=1.0.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rath"]

--- a/src/rath/__init__.py
+++ b/src/rath/__init__.py
@@ -5,14 +5,44 @@ uses :class:`~rath.flow.tool.FlowToolCall` as the flow-layer tool abstraction.
 
 Import submodules explicitly, e.g. ``rath.flow.agent_param``; ``rath.session`` is
 lazy-loaded via :func:`__getattr__`.
+
+On import this module looks for a ``.env`` file in the current working
+directory (and ancestor directories) via :func:`dotenv.find_dotenv` and loads
+it without overriding values already set in ``os.environ``. Disable by setting
+``RATH_SKIP_DOTENV=1`` before import.
 """
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from rath import backend
-from rath import flow
+
+def _load_project_dotenv() -> None:
+    """Best-effort: populate :mod:`os.environ` from a project ``.env``.
+
+    Honors ``RATH_SKIP_DOTENV`` for environments where library-side env
+    mutation is undesirable. Uses ``override=False`` so values already set
+    in the process environment win, which matches the documented
+    "``.env`` first, then process env vars" precedence in the install guide.
+    """
+
+    if os.environ.get("RATH_SKIP_DOTENV", "").strip():
+        return
+    try:
+        from dotenv import find_dotenv, load_dotenv
+    except ImportError:  # pragma: no cover -- python-dotenv is a core dep
+        return
+    path = find_dotenv(usecwd=True)
+    if path:
+        load_dotenv(path, override=False)
+
+
+_load_project_dotenv()
+
+
+from rath import backend  # noqa: E402  (load after dotenv so backends see env)
+from rath import flow  # noqa: E402
 
 __all__ = ["backend", "flow", "session"]
 

--- a/src/rath/backend/local.py
+++ b/src/rath/backend/local.py
@@ -233,13 +233,20 @@ class LocalBackend(Backend):
 
     def _files_write(
         self, sandbox: BackendSandbox, call: BackendToolFilesWrite
-    ) -> FileWriteResult:
+    ) -> FileWriteResult | ToolExecutionFailure:
         p = self._resolve(sandbox, call.path)
-        p.parent.mkdir(parents=True, exist_ok=True)
         payload_bytes = (
             call.data.encode("utf-8") if isinstance(call.data, str) else call.data
         )
-        p.write_bytes(payload_bytes)
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(payload_bytes)
+        except OSError as exc:
+            return ToolExecutionFailure(
+                kind="os_error",
+                message=str(exc),
+                detail=type(exc).__name__,
+            )
         with contextlib.suppress(OSError):
             p.chmod(call.mode)
         return FileWriteResult(bytes_written=len(payload_bytes))
@@ -269,7 +276,13 @@ class LocalBackend(Backend):
     def _files_exists(
         self, sandbox: BackendSandbox, call: BackendToolFilesExists
     ) -> bool:
-        return self._resolve(sandbox, call.path).exists()
+        try:
+            return self._resolve(sandbox, call.path).exists()
+        except OSError:
+            # Treat permission errors / unreadable parent dirs as "not present"
+            # rather than raising into the loop; matches POSIX stat() semantics
+            # from the caller's perspective.
+            return False
 
     def _code_run(
         self, sandbox: BackendSandbox, call: BackendToolCodeRun

--- a/src/rath/flow/agent.py
+++ b/src/rath/flow/agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from rath.flow.workflow import Workflow
 from rath.flow.agent_param import AgentParam
 from rath.flow.tool import FlowToolCall
@@ -11,12 +13,38 @@ class Agent(Workflow):
     def __init__(
         self,
         system_prompt: str,
-        provider: Provider,
+        provider: Provider | None = None,
         tools: list[FlowToolCall] | None = None,
         *,
+        model: str | None = None,
         chunk_print: ChunkAppendHook | None = None,
     ):
+        """Build a single-agent workflow.
+
+        ``provider`` may be a fully-formed :class:`~rath.llm.Provider` (the
+        explicit form used when you want to control api_key, base_url,
+        sampling, etc.) or omitted in favor of the shortcut ``model="..."``
+        kwarg, which constructs a :class:`Provider` with just that model name.
+
+        ``api_key`` and ``base_url`` left empty on the Provider fall back to
+        the ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables
+        (loaded from the project ``.env`` if present) inside
+        :class:`~rath.llm.RathOpenAIChatClient`, so::
+
+            flow.Agent("Use tools when helpful.", model="gpt-5.5")
+
+        is the minimal form that works once the environment is configured.
+        """
         super().__init__()
+        if provider is None and model is None:
+            raise ValueError(
+                "flow.Agent requires either provider=Provider(...) "
+                "or model=\"...\"",
+            )
+        if provider is None:
+            provider = Provider(model=model)
+        elif model is not None and provider.model is None:
+            provider = replace(provider, model=model)
         self.tools = list(tools or [])
         self._chunk_print = chunk_print
         self.agent = AgentParam(

--- a/src/rath/flow/tool/mcp_adapter.py
+++ b/src/rath/flow/tool/mcp_adapter.py
@@ -1,0 +1,236 @@
+"""Bridge an MCP stdio server into the :class:`FlowToolCall` interface.
+
+Lets OpenRath use any tool exposed by a Model Context Protocol server as if
+it were a built-in :class:`~rath.flow.tool.FlowToolCall`. Only the **stdio**
+transport is supported in this module; SSE / HTTP transports can be added
+later without changing the public surface.
+
+Install the optional extra::
+
+    pip install "openrath[mcp]"
+
+Minimal use::
+
+    from rath.flow.tool.mcp_adapter import mcp_tools_from_server
+
+    tools = mcp_tools_from_server(["python", "-m", "mcp_server_filesystem"])
+    agent = flow.Agent("Use mcp tools", Provider(model="gpt-5.5"), tools=list(tools))
+
+The implementation opens a fresh stdio subprocess for each ``list_tools``
+and each ``call_tool``. That keeps the lifecycle trivially correct under
+anyio's cancellation scopes; per-call cost is dominated by LLM latency
+in typical workflows. A long-lived session worker is a possible later
+optimization.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from typing import Any, cast
+
+from rath.backend.dedicated_loop import DedicatedEventLoopThread
+from rath.flow.tool.base import FlowToolCall
+from rath.session.session import Session
+
+try:
+    from mcp import ClientSession, StdioServerParameters  # type: ignore[import-not-found, unused-ignore]
+    from mcp.client.stdio import stdio_client  # type: ignore[import-not-found, unused-ignore]
+
+    _MCP_AVAILABLE = True
+except ImportError:  # pragma: no cover -- optional extra
+    _MCP_AVAILABLE = False
+
+
+__all__ = [
+    "MCPClient",
+    "MCPToolCall",
+    "mcp_tools_from_server",
+    "shared_mcp_loop",
+    "is_mcp_available",
+]
+
+
+def is_mcp_available() -> bool:
+    """Return whether the ``mcp`` package is importable."""
+    return _MCP_AVAILABLE
+
+
+_MCP_LOOP: DedicatedEventLoopThread | None = None
+_MCP_LOOP_LOCK = threading.Lock()
+
+
+def shared_mcp_loop() -> DedicatedEventLoopThread:
+    """Process-wide dedicated asyncio loop used by :class:`MCPClient`."""
+
+    global _MCP_LOOP
+    with _MCP_LOOP_LOCK:
+        if _MCP_LOOP is None:
+            _MCP_LOOP = DedicatedEventLoopThread()
+        return _MCP_LOOP
+
+
+class MCPClient:
+    """Sync wrapper around an MCP stdio server.
+
+    Each :meth:`list_tools` and :meth:`call_tool` opens a fresh subprocess on
+    the shared MCP loop. Construct with a list-of-string command (e.g.
+    ``["python", "-m", "mcp_server_filesystem"]``) or with positional command
+    + args::
+
+        client = MCPClient("python", args=["-m", "mcp_server_filesystem"])
+        for t in client.list_tools():
+            print(t.name)
+    """
+
+    def __init__(
+        self,
+        command: str | list[str],
+        *,
+        args: list[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        if not _MCP_AVAILABLE:  # pragma: no cover -- gated by is_mcp_available()
+            raise RuntimeError(
+                "mcp is not installed; install with `pip install openrath[mcp]`",
+            )
+        if isinstance(command, list):
+            cmd_exe = command[0]
+            cmd_args = list(command[1:])
+        else:
+            cmd_exe = command
+            cmd_args = list(args or [])
+        self._params = StdioServerParameters(
+            command=cmd_exe,
+            args=cmd_args,
+            env=dict(env) if env is not None else None,
+        )
+        self._loop = shared_mcp_loop()
+
+    def list_tools(self) -> list[Any]:
+        """Connect to the server and return its ``tools`` list (mcp.types.Tool)."""
+
+        async def _do() -> list[Any]:
+            async with stdio_client(self._params) as (r, w):
+                async with ClientSession(r, w) as session:
+                    await session.initialize()
+                    res = await session.list_tools()
+                    return list(res.tools)
+
+        return self._loop.run(_do())
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> Any:
+        """Connect to the server and run ``name`` with ``arguments``.
+
+        Returns the raw ``CallToolResult`` from the SDK; the caller decides how
+        to surface :attr:`CallToolResult.content` (typically a list of text or
+        image content parts).
+        """
+
+        async def _do() -> Any:
+            async with stdio_client(self._params) as (r, w):
+                async with ClientSession(r, w) as session:
+                    await session.initialize()
+                    return await session.call_tool(name, arguments=dict(arguments))
+
+        return self._loop.run(_do())
+
+
+def _coerce_input_schema(input_schema: Any) -> Mapping[str, Any]:
+    """Normalize the MCP ``inputSchema`` field to a JSON-schema dict.
+
+    The mcp Python SDK historically returned dict or pydantic models for this
+    field. Best-effort: prefer ``model_dump`` if available, otherwise fall
+    back to ``dict()`` cast.
+    """
+    if hasattr(input_schema, "model_dump"):
+        return cast(Mapping[str, Any], input_schema.model_dump(mode="json"))
+    if isinstance(input_schema, dict):
+        return dict(input_schema)
+    if input_schema is None:
+        return {"type": "object", "properties": {}}
+    return dict(input_schema)
+
+
+def _flatten_call_result(result: Any) -> Any:
+    """Reduce a CallToolResult to something the session loop can JSON-encode.
+
+    If the result has a ``content`` list with text parts, concatenate their
+    ``text`` attributes; otherwise return ``result`` as-is and let the loop's
+    own summarizer handle it.
+    """
+    content = getattr(result, "content", None)
+    if not content:
+        return getattr(result, "structuredContent", None) or {"ok": True}
+    parts: list[str] = []
+    for c in content:
+        text = getattr(c, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    if parts:
+        return {"text": "\n".join(parts)}
+    return {"content": [str(c) for c in content]}
+
+
+class MCPToolCall(FlowToolCall):
+    """Wraps one tool from an :class:`MCPClient` as a :class:`FlowToolCall`."""
+
+    def __init__(
+        self,
+        *,
+        client: MCPClient,
+        name: str,
+        description: str | None,
+        parameters: Mapping[str, Any],
+    ) -> None:
+        self._client = client
+        self._name = name
+        self._description = description
+        self._parameters = parameters
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str | None:
+        return self._description
+
+    @property
+    def parameters(self) -> Mapping[str, Any]:
+        return self._parameters
+
+    def __call__(
+        self, session: Session, arguments: Mapping[str, Any]
+    ) -> Any:
+        del session  # MCP tools don't get the OpenRath session
+        result = self._client.call_tool(self._name, arguments)
+        return _flatten_call_result(result)
+
+
+def mcp_tools_from_server(
+    command: str | list[str],
+    *,
+    args: list[str] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> tuple[MCPToolCall, ...]:
+    """Connect to a stdio MCP server, list its tools, return wrapped FlowToolCalls.
+
+    The returned :class:`MCPToolCall` instances all share one
+    :class:`MCPClient`, so subsequent invocations of any tool reuse the same
+    stdio command for fresh subprocesses. The caller is responsible for
+    keeping a reference to the returned tuple as long as those tools are in
+    use; there is no explicit close because each call already opens / closes
+    its own subprocess.
+    """
+    client = MCPClient(command, args=args, env=env)
+    raw_tools = client.list_tools()
+    return tuple(
+        MCPToolCall(
+            client=client,
+            name=str(t.name),
+            description=getattr(t, "description", None),
+            parameters=_coerce_input_schema(getattr(t, "inputSchema", None)),
+        )
+        for t in raw_tools
+    )

--- a/src/rath/llm/__init__.py
+++ b/src/rath/llm/__init__.py
@@ -18,13 +18,27 @@ from rath.llm.chat_response import (
     RathLLMTokenUsage,
     RathLLMToolCallFunction,
     RathLLMToolCallPart,
+    add_usage,
 )
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised by user code from ``Provider.on_budget_exceeded`` to abort a loop.
+
+    The session loop itself does not raise this automatically when
+    ``budget_total_tokens`` is exceeded - it only invokes the callback (or
+    logs a warning if no callback is set). Raising this from the callback is
+    the documented way to stop the loop on overrun.
+    """
+
 
 __all__ = [
     "Provider",
     "RathOpenAIChatClient",
+    "BudgetExceededError",
     "to_create_kwargs",
     "normalize_chat_completion",
+    "add_usage",
     "RathLLMChatRequest",
     "RathLLMMessage",
     "RathLLMFunctionTool",

--- a/src/rath/llm/_retry.py
+++ b/src/rath/llm/_retry.py
@@ -1,0 +1,83 @@
+"""Internal: exponential-backoff retry for transient OpenAI-compatible errors.
+
+Lives under ``_retry`` (single leading underscore) because it is an
+implementation detail of :class:`~rath.llm.client.RathOpenAIChatClient`. Not
+exported from :mod:`rath.llm`.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Callable, TypeVar
+
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    RateLimitError,
+)
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ATTEMPTS = 4
+DEFAULT_BASE_SECONDS = 0.5
+DEFAULT_CAP_SECONDS = 30.0
+
+_RETRYABLE: tuple[type[BaseException], ...] = (
+    RateLimitError,
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+)
+
+
+def retry_with_backoff(
+    fn: Callable[[], T],
+    *,
+    max_attempts: int | None = None,
+    base_seconds: float | None = None,
+    cap_seconds: float = DEFAULT_CAP_SECONDS,
+    jitter: bool = True,
+    sleep: Callable[[float], None] = time.sleep,
+) -> T:
+    """Call ``fn`` with exponential backoff on transient API errors.
+
+    Retries on :class:`openai.RateLimitError`, :class:`openai.APIConnectionError`,
+    :class:`openai.APITimeoutError`, and :class:`openai.InternalServerError`. All
+    other exceptions propagate immediately.
+
+    Backoff: ``base * 2**(attempt-1)`` capped at ``cap_seconds``, plus optional
+    uniform jitter in ``[0, base)``.
+
+    ``sleep`` is parameterized so tests can run without real wall-clock waits.
+    """
+    attempts = max_attempts if max_attempts is not None else DEFAULT_MAX_ATTEMPTS
+    base = base_seconds if base_seconds is not None else DEFAULT_BASE_SECONDS
+    if attempts < 1:
+        attempts = 1
+
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except _RETRYABLE as exc:
+            last_exc = exc
+            if attempt >= attempts:
+                break
+            delay = min(cap_seconds, base * (2 ** (attempt - 1)))
+            if jitter:
+                delay += random.uniform(0.0, base)
+            logger.warning(
+                "retry_with_backoff: %s on attempt %d/%d; sleeping %.2fs",
+                type(exc).__name__,
+                attempt,
+                attempts,
+                delay,
+            )
+            sleep(delay)
+    assert last_exc is not None
+    raise last_exc

--- a/src/rath/llm/chat_response.py
+++ b/src/rath/llm/chat_response.py
@@ -13,6 +13,7 @@ __all__ = [
     "RathLLMChatChoice",
     "RathLLMChatResponse",
     "RathLLMFinishReason",
+    "add_usage",
 ]
 
 RathLLMFinishReason = Literal[
@@ -93,3 +94,25 @@ class RathLLMChatResponse:
         if not self.choices:
             raise IndexError("RathLLMChatResponse has no choices")
         return self.choices[0]
+
+
+def add_usage(
+    a: RathLLMTokenUsage | None,
+    b: RathLLMTokenUsage | None,
+) -> RathLLMTokenUsage | None:
+    """Sum two token usages.
+
+    Returns ``None`` only when both inputs are ``None`` (so callers can detect
+    that no provider in the chain reported usage). Detail dicts are not merged
+    - they are dropped on the accumulated total because per-call breakdowns
+    don't sum cleanly.
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return RathLLMTokenUsage(
+        prompt_tokens=a.prompt_tokens + b.prompt_tokens,
+        completion_tokens=a.completion_tokens + b.completion_tokens,
+        total_tokens=a.total_tokens + b.total_tokens,
+    )

--- a/src/rath/llm/client.py
+++ b/src/rath/llm/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from openai import OpenAI
@@ -16,17 +17,27 @@ __all__ = ["RathOpenAIChatClient"]
 
 
 class RathOpenAIChatClient:
-    """Thin client around ``openai.OpenAI`` chat completions (non-streaming)."""
+    """Thin client around ``openai.OpenAI`` chat completions (non-streaming).
+
+    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to the
+    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables. The values
+    are typically populated from the project ``.env`` file when ``rath`` is
+    imported (see :mod:`rath.__init__`).
+    """
 
     def __init__(self, provider: Provider) -> None:
-        key = (provider.api_key or "").strip()
+        key = (provider.api_key or os.environ.get("OPENAI_API_KEY") or "").strip()
         if not key:
             raise ValueError(
-                "Provider.api_key is required to construct RathOpenAIChatClient",
+                "OPENAI_API_KEY is not set and Provider.api_key is empty; "
+                "either pass api_key= to Provider(...) or export "
+                "OPENAI_API_KEY (e.g. via a project .env file).",
             )
         self._provider = provider
         init_kw: dict[str, Any] = {"api_key": key}
-        bu = (provider.base_url or "").strip()
+        bu = (
+            provider.base_url or os.environ.get("OPENAI_BASE_URL") or ""
+        ).strip()
         if bu:
             init_kw["base_url"] = bu
         self._client = OpenAI(**init_kw)

--- a/src/rath/llm/client.py
+++ b/src/rath/llm/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from openai import OpenAI
+from openai import AzureOpenAI, OpenAI
 
 from rath.llm.openai_create_kwargs import to_create_kwargs
 from rath.llm.openai_normalize import normalize_chat_completion
@@ -16,31 +16,96 @@ from rath.llm.provider import Provider
 __all__ = ["RathOpenAIChatClient"]
 
 
+def _is_azure_endpoint(url: str) -> bool:
+    return ".azure.com" in url or ".cognitiveservices.azure.com" in url
+
+
+def _resolve_base_url(provider: Provider) -> str:
+    """Pick the first non-empty source: provider, OPENAI_BASE_URL, AZURE_OPENAI_ENDPOINT."""
+    for candidate in (
+        provider.base_url,
+        os.environ.get("OPENAI_BASE_URL"),
+        os.environ.get("AZURE_OPENAI_ENDPOINT"),
+    ):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
+def _resolve_api_key(provider: Provider, base_url: str) -> str:
+    """Pick the first non-empty source.
+
+    For Azure endpoints, Azure-specific env vars are tried first; otherwise
+    ``OPENAI_API_KEY`` wins. ``Provider.api_key`` always takes precedence.
+    """
+    sources: list[str | None] = [provider.api_key]
+    if _is_azure_endpoint(base_url):
+        sources += [
+            os.environ.get("AZURE_OPENAI_API_KEY"),
+            os.environ.get("AZURE_API_KEY"),
+            os.environ.get("OPENAI_API_KEY"),
+        ]
+    else:
+        sources += [
+            os.environ.get("OPENAI_API_KEY"),
+            os.environ.get("AZURE_OPENAI_API_KEY"),
+        ]
+    for candidate in sources:
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
 class RathOpenAIChatClient:
     """Thin client around ``openai.OpenAI`` chat completions (non-streaming).
 
-    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to the
-    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` environment variables. The values
-    are typically populated from the project ``.env`` file when ``rath`` is
-    imported (see :mod:`rath.__init__`).
+    Empty ``Provider.api_key`` / ``Provider.base_url`` fall back to environment
+    variables, typically loaded from the project ``.env`` (see
+    :mod:`rath.__init__`):
+
+    * ``base_url``: ``OPENAI_BASE_URL`` then ``AZURE_OPENAI_ENDPOINT``.
+    * ``api_key``: ``OPENAI_API_KEY`` for OpenAI-compatible endpoints; for
+      ``*.azure.com`` endpoints the order becomes
+      ``AZURE_OPENAI_API_KEY`` → ``AZURE_API_KEY`` → ``OPENAI_API_KEY``.
+
+    Azure endpoints exposing the new ``/openai/v1`` surface speak plain
+    OpenAI Chat Completions, so the vanilla SDK is used. Legacy Azure
+    endpoints (``/openai`` without ``/v1``) are routed through
+    :class:`openai.AzureOpenAI` with ``api_version`` taken from
+    ``OPENAI_API_VERSION`` (default ``2024-10-21``).
     """
 
     def __init__(self, provider: Provider) -> None:
-        key = (provider.api_key or os.environ.get("OPENAI_API_KEY") or "").strip()
+        base_url = _resolve_base_url(provider)
+        key = _resolve_api_key(provider, base_url)
         if not key:
             raise ValueError(
-                "OPENAI_API_KEY is not set and Provider.api_key is empty; "
-                "either pass api_key= to Provider(...) or export "
-                "OPENAI_API_KEY (e.g. via a project .env file).",
+                "No API key found: Provider.api_key is empty and none of "
+                "OPENAI_API_KEY / AZURE_OPENAI_API_KEY / AZURE_API_KEY are "
+                "set. Pass api_key= to Provider(...) or export one of these "
+                "(e.g. via a project .env file).",
             )
         self._provider = provider
-        init_kw: dict[str, Any] = {"api_key": key}
-        bu = (
-            provider.base_url or os.environ.get("OPENAI_BASE_URL") or ""
-        ).strip()
-        if bu:
-            init_kw["base_url"] = bu
-        self._client = OpenAI(**init_kw)
+
+        use_azure_legacy = (
+            _is_azure_endpoint(base_url) and "/openai/v1" not in base_url
+        )
+        if use_azure_legacy:
+            api_version = (
+                os.environ.get("OPENAI_API_VERSION")
+                or os.environ.get("AZURE_OPENAI_API_VERSION")
+                or "2024-10-21"
+            )
+            self._client = AzureOpenAI(
+                api_key=key,
+                azure_endpoint=base_url,
+                api_version=api_version,
+            )
+        else:
+            init_kw: dict[str, Any] = {"api_key": key}
+            if base_url:
+                init_kw["base_url"] = base_url
+            self._client = OpenAI(**init_kw)
 
     @property
     def provider(self) -> Provider:

--- a/src/rath/llm/client.py
+++ b/src/rath/llm/client.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from openai import AzureOpenAI, OpenAI
 
+from rath.llm._retry import retry_with_backoff
 from rath.llm.openai_create_kwargs import to_create_kwargs
 from rath.llm.openai_normalize import normalize_chat_completion
 from rath.llm.chat_request import RathLLMChatRequest
@@ -112,7 +113,23 @@ class RathOpenAIChatClient:
         return self._provider
 
     def complete(self, req: RathLLMChatRequest) -> RathLLMChatResponse:
-        """Run ``chat.completions.create`` and normalize the response."""
-        kwargs = to_create_kwargs(req, default_model=self._provider.model)
-        completion = self._client.chat.completions.create(**kwargs)
-        return normalize_chat_completion(completion)
+        """Run ``chat.completions.create`` and normalize the response.
+
+        Transient errors (rate limit, connection, timeout, server 5xx) are
+        retried with exponential backoff per :attr:`Provider.retry_max_attempts`
+        and :attr:`Provider.retry_base_seconds`.
+        """
+        default_model = (
+            self._provider.model or os.environ.get("OPENAI_DEFAULT_MODEL")
+        )
+        kwargs = to_create_kwargs(req, default_model=default_model)
+
+        def _call() -> RathLLMChatResponse:
+            completion = self._client.chat.completions.create(**kwargs)
+            return normalize_chat_completion(completion)
+
+        return retry_with_backoff(
+            _call,
+            max_attempts=self._provider.retry_max_attempts,
+            base_seconds=self._provider.retry_base_seconds,
+        )

--- a/src/rath/llm/provider.py
+++ b/src/rath/llm/provider.py
@@ -51,10 +51,14 @@ class Provider:
     # the built-in defaults in :mod:`rath.llm._retry`.
     retry_max_attempts: int | None = None
     retry_base_seconds: float | None = None
-    # Token budget guardrail. When non-None and ``Session.cumulative_usage``
-    # exceeds ``budget_total_tokens`` after a completion, ``on_budget_exceeded``
-    # is invoked (or a default ``logger.warning`` is emitted). The callback
-    # may raise :class:`BudgetExceededError` to abort the loop.
+    # Token budget guardrail. When non-None, the **first** completion in a
+    # ``run_session_loop`` that pushes ``Session.cumulative_usage`` past the
+    # cap invokes ``on_budget_exceeded`` (or emits a single
+    # ``logger.warning`` if no callback is set). The guard is latched per
+    # session: subsequent completions in the same loop do not re-fire it
+    # even if the running total stays above the cap. Callers that want to
+    # abort the loop are expected to raise
+    # :class:`BudgetExceededError` from the callback on that first call.
     budget_total_tokens: int | None = None
     on_budget_exceeded: Callable[..., None] | None = None
 

--- a/src/rath/llm/provider.py
+++ b/src/rath/llm/provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -47,6 +47,16 @@ class Provider:
     extra_create_args: Mapping[str, Any] = field(
         default_factory=lambda: MappingProxyType({})
     )
+    # Retry policy for transient OpenAI-compatible errors. ``None`` means use
+    # the built-in defaults in :mod:`rath.llm._retry`.
+    retry_max_attempts: int | None = None
+    retry_base_seconds: float | None = None
+    # Token budget guardrail. When non-None and ``Session.cumulative_usage``
+    # exceeds ``budget_total_tokens`` after a completion, ``on_budget_exceeded``
+    # is invoked (or a default ``logger.warning`` is emitted). The callback
+    # may raise :class:`BudgetExceededError` to abort the loop.
+    budget_total_tokens: int | None = None
+    on_budget_exceeded: Callable[..., None] | None = None
 
     def __str__(self) -> str:
         return self.model if self.model is not None else "(no model)"

--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -77,7 +77,16 @@ def run_session_compress(
         default_tool_choice="none",
     )
 
-    sb = user_session.take_sandbox()
+    # Compress is a pure-LLM operation (tool_choice is forced to "none"); a
+    # sandbox is only useful for rebinding to the output session. Skip
+    # take_sandbox() entirely when the caller has not attached one, so
+    # Session.from_user_message("...") works without a prior .to("local").
+    sb = None
+    if (
+        user_session.sandbox is not None
+        or user_session.sandbox_backend is not None
+    ):
+        sb = user_session.take_sandbox()
     body = _completion_body(executor.complete(req))
     if body is None or not str(body).strip():
         raise RuntimeError("run_session_compress: empty model content")
@@ -93,7 +102,8 @@ def run_session_compress(
             operator="run_session_compress",
         ),
     )
-    out.bind_sandbox(sb)
+    if sb is not None:
+        out.bind_sandbox(sb)
 
     LineageRecorder.stamp_new_session(
         out,

--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -40,8 +40,10 @@ def run_session_compress(
     Completions use ``tools=None`` and ``tool_choice=none``. If the model returns tool
     calls, raises ``RuntimeError``.
 
-    When ``executor`` is ``None``, a default executor is built from ``agent_provider``;
-    it must carry a non-empty ``api_key``.
+    When ``executor`` is ``None``, a default executor is built from ``agent_provider``.
+    Empty ``agent_provider.api_key`` falls back to
+    ``OPENAI_API_KEY`` / ``AZURE_OPENAI_API_KEY`` (see
+    :class:`~rath.llm.client.RathOpenAIChatClient` for the full lookup order).
 
     Rebases sandbox from ``user_session`` onto the returned session (same as the loop).
 
@@ -50,11 +52,6 @@ def run_session_compress(
     """
 
     if executor is None:
-        if not (agent_provider.api_key and str(agent_provider.api_key).strip()):
-            raise ValueError(
-                "agent_provider.api_key is required when executor is None "
-                "(build a Provider with api_key, or pass a SessionLoopExecutor).",
-            )
         executor = DefaultSessionLoopExecutor(RathOpenAIChatClient(agent_provider))
 
     instruction = (

--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from rath.llm import Provider, RathOpenAIChatClient, RathLLMMessage, RathLLMChatResponse
+from rath.llm import (
+    Provider,
+    RathLLMChatResponse,
+    RathLLMMessage,
+    RathOpenAIChatClient,
+    add_usage,
+)
 from rath.session.chunk import ChunkTable, chunk_table_to_messages, user_text_chunk
 from rath.session.chat_request_build import provider_into_chat_request
 from rath.session.graph import LineageKind, LineageRecorder, SessionLineage
@@ -84,7 +90,8 @@ def run_session_compress(
         or user_session.sandbox_backend is not None
     ):
         sb = user_session.take_sandbox()
-    body = _completion_body(executor.complete(req))
+    resp = executor.complete(req)
+    body = _completion_body(resp)
     if body is None or not str(body).strip():
         raise RuntimeError("run_session_compress: empty model content")
 
@@ -98,6 +105,7 @@ def run_session_compress(
             producer_system_session_id=agent_session.id,
             operator="run_session_compress",
         ),
+        cumulative_usage=add_usage(None, resp.usage),
     )
     if sb is not None:
         out.bind_sandbox(sb)

--- a/src/rath/session/graph/__init__.py
+++ b/src/rath/session/graph/__init__.py
@@ -24,6 +24,12 @@ from rath.session.graph.traverse import (
     lineage_view_dataclass,
     validate_acyclic,
 )
+from rath.session.graph.export import (
+    export_journal_jsonl,
+    export_jsonl,
+    export_jsonl_string,
+    session_to_jsonl_row,
+)
 
 __all__ = [
     "FrozenLineageView",
@@ -35,10 +41,14 @@ __all__ = [
     "ancestors_bfs",
     "descendants_dfs_preorder",
     "edge_pairs",
+    "export_journal_jsonl",
+    "export_jsonl",
+    "export_jsonl_string",
     "lineage_journal_optional",
     "lineage_journal_tracking",
     "lineage_view_dataclass",
     "session_graph_mode",
     "session_graph_mode_override",
+    "session_to_jsonl_row",
     "validate_acyclic",
 ]

--- a/src/rath/session/graph/export.py
+++ b/src/rath/session/graph/export.py
@@ -1,0 +1,110 @@
+"""JSONL (newline-delimited JSON) export for session lineage graphs.
+
+One Session per line. Edges are not materialized - ``parent_session_ids`` on
+each row implies them - so the format is friendly to ``jq``, streaming
+parsers, and naive Mermaid converters. Pair with
+:class:`~rath.session.graph.LineageJournal` to dump only the sessions
+visited inside a given block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from rath.session.graph.recording import LineageJournal
+from rath.session.manager import session_registry
+from rath.session.session import Session
+
+
+__all__ = [
+    "session_to_jsonl_row",
+    "export_jsonl_string",
+    "export_jsonl",
+    "export_journal_jsonl",
+]
+
+
+def _usage_to_jsonable(session: Session) -> dict[str, int] | None:
+    usage = session.cumulative_usage
+    if usage is None:
+        return None
+    return {
+        "prompt_tokens": usage.prompt_tokens,
+        "completion_tokens": usage.completion_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _lineage_extras_to_jsonable(
+    extras: tuple[tuple[str, Any], ...],
+) -> list[list[Any]]:
+    """Convert lineage_extras (tuple of pairs) into a JSONable list of pairs.
+
+    Values that are not natively JSON-serializable are coerced to ``str(value)``
+    so the row never fails to dump.
+    """
+    out: list[list[Any]] = []
+    for key, value in extras:
+        try:
+            json.dumps(value)
+            jvalue = value
+        except (TypeError, ValueError):
+            jvalue = str(value)
+        out.append([str(key), jvalue])
+    return out
+
+
+def session_to_jsonl_row(session: Session) -> dict[str, Any]:
+    """Project a :class:`Session` into a JSONable dict for one JSONL row."""
+    return {
+        "id": str(session.id),
+        "parent_session_ids": [str(p) for p in session.parent_session_ids],
+        "lineage_operator": session.lineage_operator,
+        "lineage_kind": session.lineage_kind.value,
+        "lineage_extras": _lineage_extras_to_jsonable(session.lineage_extras),
+        "chunk_count": len(session.chunk_table.rows),
+        "cumulative_usage": _usage_to_jsonable(session),
+    }
+
+
+def export_jsonl_string(sessions: Iterable[Session]) -> str:
+    """Return the JSONL text for ``sessions`` (one line per session, ``\\n``-terminated)."""
+    parts: list[str] = []
+    for s in sessions:
+        parts.append(json.dumps(session_to_jsonl_row(s), ensure_ascii=False))
+    return "\n".join(parts) + ("\n" if parts else "")
+
+
+def export_jsonl(sessions: Iterable[Session], path: str | Path) -> None:
+    """Write JSONL for ``sessions`` to ``path`` (UTF-8, ``\\n`` line endings)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    text = export_jsonl_string(sessions)
+    p.write_text(text, encoding="utf-8")
+
+
+def export_journal_jsonl(
+    journal: LineageJournal,
+    path: str | Path,
+    *,
+    skip_unknown: bool = True,
+) -> None:
+    """Resolve ``journal.visit_order`` through the session registry, then export.
+
+    Sessions that are not in the global registry are silently skipped when
+    ``skip_unknown`` is true (the default - this matches the typical use case
+    where the journal outlives some sessions). Set ``skip_unknown=False`` to
+    raise :class:`KeyError` instead.
+    """
+    reg = session_registry()
+    rows: list[Session] = []
+    for sid in journal.visit_order:
+        s = reg.get(sid)
+        if s is None:
+            if skip_unknown:
+                continue
+            raise KeyError(f"session {sid} not in registry")
+        rows.append(s)
+    export_jsonl(rows, path)

--- a/src/rath/session/graph/recording.py
+++ b/src/rath/session/graph/recording.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Generator
 from uuid import UUID
 
@@ -16,17 +16,33 @@ _SESSION_GRAPH_MODE: ContextVar[bool] = ContextVar(
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class LineageJournal:
-    """Append-only visitation log (immutable).
+    """Append-only visitation log mutated in place.
 
     Ordered session ids visited in this run; edges are not materialized.
+
+    Mutable on purpose so that callers can read ``visit_order`` after the
+    :func:`lineage_journal_tracking` context manager exits. Use
+    :meth:`record` from primitives that stamp lineage; do not mutate
+    ``visit_order`` directly.
     """
 
-    visit_order: tuple[UUID, ...] = ()
+    visit_order: list[UUID] = field(default_factory=list)
+
+    def record(self, session_id: UUID) -> None:
+        """Append ``session_id`` to ``visit_order`` in place."""
+        self.visit_order.append(session_id)
 
     def append(self, session_id: UUID) -> LineageJournal:
-        return LineageJournal(visit_order=self.visit_order + (session_id,))
+        """Deprecated: returns ``self`` after :meth:`record` for legacy callers.
+
+        Earlier versions returned a fresh instance, which silently dropped
+        updates when used through the ContextVar. New code should call
+        :meth:`record` directly.
+        """
+        self.visit_order.append(session_id)
+        return self
 
 
 _LINEAGE_JOURNAL: ContextVar[LineageJournal | None] = ContextVar(
@@ -65,12 +81,20 @@ def lineage_journal_optional() -> LineageJournal | None:
 def lineage_journal_tracking(
     *,
     journal: LineageJournal | None = None,
-) -> Generator[None, None, None]:
-    """Attach ``LineageJournal`` (fresh by default); reset afterwards."""
+) -> Generator[LineageJournal, None, None]:
+    """Attach a :class:`LineageJournal` for this block and yield it.
+
+    The yielded journal is mutated in place by :meth:`LineageRecorder.stamp_new_session`
+    as new sessions are created inside the block; ``visit_order`` is readable
+    after the context manager exits.
+
+    Existing callers that wrote ``with lineage_journal_tracking():`` still
+    work because the yielded value can be discarded.
+    """
     j = journal if journal is not None else LineageJournal()
     tok: Token[LineageJournal | None] = _LINEAGE_JOURNAL.set(j)
     try:
-        yield None
+        yield j
     finally:
         _LINEAGE_JOURNAL.reset(tok)
 
@@ -102,7 +126,7 @@ class LineageRecorder:
         session.lineage_extras = lineage_extras
         lj = lineage_journal_optional()
         if lj is not None:
-            _LINEAGE_JOURNAL.set(lj.append(session.id))
+            lj.record(session.id)
 
 
 __all__ = [

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -112,18 +112,28 @@ def _accumulate_usage_and_check_budget(
 ) -> None:
     """Fold ``resp.usage`` into ``out.cumulative_usage`` and trip the budget guard.
 
-    If ``provider.budget_total_tokens`` is set and the running total crosses it,
-    call ``provider.on_budget_exceeded(out, out.cumulative_usage)``; if no
-    callback is set, log a warning. The callback may raise
-    :class:`~rath.llm.BudgetExceededError` to abort the loop.
+    The guard fires **only on the completion that first pushes the running
+    total past ``provider.budget_total_tokens``**, never again for the same
+    ``out`` session. That keeps a multi-round tool-calling loop from
+    re-invoking the callback (or re-logging the warning) every round once the
+    cap has already been crossed; callers that want to abort the loop are
+    expected to raise :class:`~rath.llm.BudgetExceededError` from the
+    callback on that first call.
+
+    The latch is implicit in the prev/new transition (``prev <= cap`` and
+    ``new > cap``); no new session state is introduced.
     """
     if resp.usage is None:
         return
+    prev_total = (
+        out.cumulative_usage.total_tokens if out.cumulative_usage is not None else 0
+    )
     out.cumulative_usage = add_usage(out.cumulative_usage, resp.usage)
     cap = provider.budget_total_tokens
     if cap is None or out.cumulative_usage is None:
         return
-    if out.cumulative_usage.total_tokens <= cap:
+    new_total = out.cumulative_usage.total_tokens
+    if new_total <= cap or prev_total > cap:
         return
     callback = provider.on_budget_exceeded
     if callback is None:
@@ -132,7 +142,7 @@ def _accumulate_usage_and_check_budget(
             "(cumulative=%d); no callback configured",
             out.id,
             cap,
-            out.cumulative_usage.total_tokens,
+            new_total,
         )
         return
     callback(out, out.cumulative_usage)

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -30,6 +30,7 @@ from rath.llm import (
     RathLLMChatResponse,
     RathLLMFunctionTool,
     RathOpenAIChatClient,
+    add_usage,
 )
 from rath.session.chat_request_build import provider_into_chat_request
 from rath.session.provider_builtin import DefaultSessionLoopExecutor
@@ -102,6 +103,39 @@ def _notify_chunk_append(
 
 def _sync_loop_out_rows(out: Session, rows_list: list[Any]) -> None:
     out.chunk_table = ChunkTable(rows=tuple(rows_list))
+
+
+def _accumulate_usage_and_check_budget(
+    out: Session,
+    resp: RathLLMChatResponse,
+    provider: Provider,
+) -> None:
+    """Fold ``resp.usage`` into ``out.cumulative_usage`` and trip the budget guard.
+
+    If ``provider.budget_total_tokens`` is set and the running total crosses it,
+    call ``provider.on_budget_exceeded(out, out.cumulative_usage)``; if no
+    callback is set, log a warning. The callback may raise
+    :class:`~rath.llm.BudgetExceededError` to abort the loop.
+    """
+    if resp.usage is None:
+        return
+    out.cumulative_usage = add_usage(out.cumulative_usage, resp.usage)
+    cap = provider.budget_total_tokens
+    if cap is None or out.cumulative_usage is None:
+        return
+    if out.cumulative_usage.total_tokens <= cap:
+        return
+    callback = provider.on_budget_exceeded
+    if callback is None:
+        logger.warning(
+            "session %s exceeded budget_total_tokens=%d "
+            "(cumulative=%d); no callback configured",
+            out.id,
+            cap,
+            out.cumulative_usage.total_tokens,
+        )
+        return
+    callback(out, out.cumulative_usage)
 
 
 @runtime_checkable
@@ -298,6 +332,7 @@ def run_session_loop(
             default_tool_choice="auto",
         )
         resp = executor.complete(req)
+        _accumulate_usage_and_check_budget(out, resp, prefs)
         choice = resp.primary_choice
         msg = choice.message
         tcalls = msg.tool_calls

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -235,7 +235,9 @@ def run_session_loop(
     ``executor``.     When ``executor`` is omitted, builds a fresh
     :class:`~rath.session.provider_builtin.DefaultSessionLoopExecutor`
     wrapping :class:`~rath.llm.client.RathOpenAIChatClient` built from
-    ``agent_provider`` (which must include a non-empty ``api_key``).
+    ``agent_provider``. Empty ``agent_provider.api_key`` falls back to
+    ``OPENAI_API_KEY`` / ``AZURE_OPENAI_API_KEY`` (see
+    :class:`~rath.llm.client.RathOpenAIChatClient` for the full lookup order).
 
     Message assembly concatenates ``agent_session.chunk_table`` ahead of user rows for
     the LLM; head rows stay out of ``out.chunk_table`` (assistant + tool-result only).
@@ -252,11 +254,6 @@ def run_session_loop(
     table = merge_tools_for_loop(tools)
 
     if executor is None:
-        if not (agent_provider.api_key and str(agent_provider.api_key).strip()):
-            raise ValueError(
-                "agent_provider.api_key is required when executor is None "
-                "(build a Provider with api_key, or pass a SessionLoopExecutor).",
-            )
         executor = DefaultSessionLoopExecutor(RathOpenAIChatClient(agent_provider))
 
     prefs = agent_provider

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -366,6 +366,18 @@ def run_session_loop(
         _notify_chunk_append(chunk_print, rows_list, out)
         if choice.finish_reason in ("stop", "length", "content_filter"):
             break
+    else:
+        # Loop exhausted max_tool_rounds without a natural finish_reason.
+        # The last row may be a tool_result, which is easy to mistake for
+        # a mid-run failure. Warn and stamp lineage so callers can detect
+        # truncation programmatically.
+        logger.warning(
+            "run_session_loop hit max_tool_rounds=%d without "
+            "finish_reason in (stop, length, content_filter); "
+            "last row may be a tool_result",
+            max_tool_rounds,
+        )
+        out.lineage_extras = out.lineage_extras + (("loop.truncated", True),)
 
     out.chunk_table = ChunkTable(rows=tuple(rows_list))
     reg.set_active(out)

--- a/src/rath/session/session.py
+++ b/src/rath/session/session.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from rath.backend import BackendSandbox, BackendSandboxSpec, get
+from rath.llm.chat_response import RathLLMTokenUsage
 from rath.session.chunk import ChunkKind, ChunkRow, ChunkTable
 from rath.session.graph.kind import LineageKind
 from rath.session.graph.recording import LineageRecorder
@@ -127,6 +128,11 @@ class Session:
     lineage_operator: str = "implicit"
     lineage_kind: LineageKind = LineageKind.UNKNOWN
     lineage_extras: tuple[tuple[str, Any], ...] = ()
+    # Running total of LLM token usage attributed to this session. Set by
+    # run_session_loop / run_session_compress after each completion. ``None``
+    # before any completion has been folded in. Not propagated by fork() /
+    # detach() - derived sessions start at zero.
+    cumulative_usage: RathLLMTokenUsage | None = None
 
     @classmethod
     def from_agent_prompt(cls, prompt: str) -> Session:

--- a/tests/backends/test_local.py
+++ b/tests/backends/test_local.py
@@ -78,6 +78,23 @@ def test_user_supplied_working_dir_honoured(tmp_path: object) -> None:
     assert os.path.isdir(target)
 
 
+def test_close_does_not_remove_user_supplied_working_dir(tmp_path: object) -> None:
+    """``close()`` must NOT rmtree a directory the caller supplied."""
+    import pathlib
+
+    target = pathlib.Path(str(tmp_path)) / "keep"  # type: ignore[arg-type]
+    target.mkdir()
+    sentinel = target / "important.txt"
+    sentinel.write_text("do not delete me", encoding="utf-8")
+
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(target)))
+    backend.close(sb)
+
+    assert target.is_dir(), "user-supplied working_dir was removed by close()"
+    assert sentinel.read_text(encoding="utf-8") == "do not delete me"
+
+
 def test_command_missing_executable_returns_failure() -> None:
     backend = get("local")
     with backend.open() as sb:

--- a/tests/backends/test_local.py
+++ b/tests/backends/test_local.py
@@ -101,3 +101,45 @@ def test_command_missing_executable_returns_failure() -> None:
         r = sb.dispatch(BackendToolCommandRun(cmd=["/nonexistent/rath_no_such_exe_xyz"]))
         assert isinstance(r, ToolExecutionFailure)
         assert r.kind in ("os_error", "unexpected")
+
+
+def test_files_write_returns_failure_when_parent_unwritable(tmp_path: object) -> None:
+    """OSError on write must surface as ToolExecutionFailure, not bubble up."""
+    import pathlib
+    import stat
+
+    root = pathlib.Path(str(tmp_path)) / "ro"  # type: ignore[arg-type]
+    root.mkdir()
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(root)))
+    try:
+        # Remove all write bits from the sandbox root so writing a new file
+        # under it raises PermissionError on POSIX.
+        root.chmod(stat.S_IRUSR | stat.S_IXUSR)
+        r = sb.dispatch(BackendToolFilesWrite(path="should_fail.txt", data="x"))
+        assert isinstance(r, ToolExecutionFailure)
+        assert r.kind == "os_error"
+    finally:
+        # Restore permissions so tmp_path cleanup doesn't fail.
+        root.chmod(stat.S_IRWXU)
+        backend.close(sb)
+
+
+def test_files_exists_returns_false_on_permission_denied(tmp_path: object) -> None:
+    """exists() against an unreadable parent must return False, not raise."""
+    import pathlib
+    import stat
+
+    root = pathlib.Path(str(tmp_path)) / "denied"  # type: ignore[arg-type]
+    root.mkdir()
+    backend = get("local")
+    sb = backend.open(BackendSandboxSpec(working_dir=str(root)))
+    try:
+        # No-permission directory: stat on a child should raise OSError;
+        # _files_exists must swallow it and return False.
+        root.chmod(0)
+        result = sb.dispatch(BackendToolFilesExists(path="anything"))
+        assert result is False
+    finally:
+        root.chmod(stat.S_IRWXU)
+        backend.close(sb)

--- a/tests/flow/test_mcp_adapter.py
+++ b/tests/flow/test_mcp_adapter.py
@@ -1,0 +1,89 @@
+"""MCP stdio adapter tests.
+
+Skipped entirely when the ``mcp`` extra is not installed (the default for
+``uv sync --group dev``). When available, exercises the full subprocess
+round-trip via the in-tree ``example/_demo_echo_server.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from rath.flow.tool.mcp_adapter import (
+    _coerce_input_schema,
+    _flatten_call_result,
+    is_mcp_available,
+)
+
+mcp_required = pytest.mark.skipif(
+    not is_mcp_available(),
+    reason="mcp not installed (run `uv sync --extra mcp`)",
+)
+
+
+_DEMO_SERVER = Path(__file__).resolve().parents[2] / "example" / "_demo_echo_server.py"
+
+
+def test_coerce_input_schema_passes_dict_through() -> None:
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    assert _coerce_input_schema(schema) == schema
+
+
+def test_coerce_input_schema_handles_none() -> None:
+    assert _coerce_input_schema(None) == {"type": "object", "properties": {}}
+
+
+def test_flatten_call_result_text_content() -> None:
+    class _Part:
+        text = "hello"
+
+    class _Result:
+        content = [_Part(), _Part()]
+        structuredContent = None
+
+    out = _flatten_call_result(_Result())
+    assert out == {"text": "hello\nhello"}
+
+
+def test_flatten_call_result_empty_content_uses_structured() -> None:
+    class _Result:
+        content: list[object] = []
+        structuredContent = {"ok": True, "rows": 3}
+
+    assert _flatten_call_result(_Result()) == {"ok": True, "rows": 3}
+
+
+@mcp_required
+def test_list_tools_against_demo_echo_server() -> None:
+    from rath.flow.tool.mcp_adapter import MCPClient
+
+    client = MCPClient([sys.executable, str(_DEMO_SERVER)])
+    tools = client.list_tools()
+    names = [t.name for t in tools]
+    assert "echo" in names
+
+
+@mcp_required
+def test_call_tool_round_trips_text() -> None:
+    from rath.flow.tool.mcp_adapter import mcp_tools_from_server
+    from rath.session import Session
+
+    tools = mcp_tools_from_server([sys.executable, str(_DEMO_SERVER)])
+    echo = next(t for t in tools if t.name == "echo")
+    result = echo(Session.from_user_message("dummy"), {"text": "ping"})
+    assert result == {"text": "ping"}
+
+
+@mcp_required
+def test_mcp_tool_call_exposes_openai_style_schema() -> None:
+    """``parameters`` must be a JSON-schema object suitable for OpenAI tools[]."""
+    from rath.flow.tool.mcp_adapter import mcp_tools_from_server
+
+    tools = mcp_tools_from_server([sys.executable, str(_DEMO_SERVER)])
+    echo = next(t for t in tools if t.name == "echo")
+    assert echo.parameters.get("type") == "object"
+    assert "properties" in echo.parameters
+    assert echo.description == "Echo the provided text back to the caller."

--- a/tests/flow/test_workflow_agent.py
+++ b/tests/flow/test_workflow_agent.py
@@ -37,6 +37,44 @@ class _ScriptedEchoWorkflow(Workflow):
         )
 
 
+def test_agent_accepts_model_kwarg_without_provider() -> None:
+    """``flow.Agent(prompt, model=\"...\")`` is the minimal-form documented in
+    the install guide; it must build a Provider with the given model so the
+    one-liner example actually runs."""
+    from rath import flow
+
+    a = flow.Agent("You are concise.", model="gpt-5.5")
+    assert a.agent.provider.model == "gpt-5.5"
+    assert a.agent.provider.api_key is None  # api_key picked up from env at call time
+
+
+def test_agent_explicit_provider_still_works() -> None:
+    from rath import flow
+
+    p = Provider(model="gpt-5.5", api_key="sk-fake")
+    a = flow.Agent("You are concise.", p)
+    assert a.agent.provider is p
+
+
+def test_agent_model_kwarg_supplements_provider_without_model() -> None:
+    """When the caller passes a provider that has no model set, the ``model=``
+    kwarg should fill it in (last-mile convenience)."""
+    from rath import flow
+
+    p = Provider(api_key="sk-fake")
+    a = flow.Agent("x", p, model="gpt-5.5")
+    assert a.agent.provider.model == "gpt-5.5"
+    # api_key is preserved from the explicit provider
+    assert a.agent.provider.api_key == "sk-fake"
+
+
+def test_agent_requires_provider_or_model() -> None:
+    from rath import flow
+
+    with pytest.raises(ValueError, match="provider"):
+        flow.Agent("x")
+
+
 def test_workflow_registers_agent_and_runs_loop() -> None:
     scripted = RathLLMChatResponse(
         id="wf1",

--- a/tests/llm/test_client_env_fallback.py
+++ b/tests/llm/test_client_env_fallback.py
@@ -1,0 +1,113 @@
+"""Construction-only tests for env-variable fallbacks in RathOpenAIChatClient.
+
+No network: ``openai.OpenAI(api_key=...)`` builds lazily, so we can assert how
+``RathOpenAIChatClient`` resolves api_key/base_url across env vars without
+hitting any remote endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+
+from openai import AzureOpenAI, OpenAI
+
+from rath.llm.client import RathOpenAIChatClient
+from rath.llm.provider import Provider
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    for name in (
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_API_KEY",
+        "OPENAI_API_VERSION",
+        "AZURE_OPENAI_API_VERSION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def test_provider_api_key_takes_precedence_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    client = RathOpenAIChatClient(Provider(api_key="from-provider"))
+    assert isinstance(client._client, OpenAI)
+    assert client._client.api_key == "from-provider"
+
+
+def test_openai_api_key_env_fallback_when_provider_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, OpenAI)
+    assert client._client.api_key == "env-key"
+
+
+def test_missing_everywhere_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(ValueError, match="No API key found"):
+        RathOpenAIChatClient(Provider())
+
+
+def test_azure_v1_endpoint_uses_vanilla_openai_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Azure's ``/openai/v1`` surface is OpenAI-compatible — vanilla SDK."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.cognitiveservices.azure.com/openai/v1",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-v1-key")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, OpenAI)
+    assert not isinstance(client._client, AzureOpenAI)
+    assert client._client.api_key == "azure-v1-key"
+    assert "cognitiveservices.azure.com/openai/v1" in str(client._client.base_url)
+
+
+def test_azure_legacy_endpoint_uses_azure_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy ``/openai`` (no ``/v1``) routes through ``AzureOpenAI``."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.openai.azure.com/openai",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-legacy-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-12-01")
+    client = RathOpenAIChatClient(Provider())
+    assert isinstance(client._client, AzureOpenAI)
+    assert client._client.api_key == "azure-legacy-key"
+    # AzureOpenAI exposes api_version on the client
+    assert client._client._api_version == "2024-12-01"
+
+
+def test_azure_endpoint_prefers_azure_env_keys_over_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When base_url is Azure, AZURE_OPENAI_API_KEY beats OPENAI_API_KEY."""
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://example.cognitiveservices.azure.com/openai/v1",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-wins")
+    monkeypatch.setenv("OPENAI_API_KEY", "should-be-ignored")
+    client = RathOpenAIChatClient(Provider())
+    assert client._client.api_key == "azure-wins"
+
+
+def test_non_azure_endpoint_prefers_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For a non-Azure base_url, OPENAI_API_KEY wins (Azure vars are a fallback)."""
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-should-lose")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-wins")
+    client = RathOpenAIChatClient(Provider())
+    assert client._client.api_key == "openai-wins"

--- a/tests/session/test_lineage_export.py
+++ b/tests/session/test_lineage_export.py
@@ -1,0 +1,110 @@
+"""JSONL lineage exporter (:mod:`rath.session.graph.export`)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from rath.session import Session
+from rath.session.graph import (
+    LineageJournal,
+    LineageKind,
+    LineageRecorder,
+    export_journal_jsonl,
+    export_jsonl,
+    export_jsonl_string,
+    lineage_journal_tracking,
+    session_to_jsonl_row,
+)
+from rath.session.manager import session_registry
+
+
+def _stamped(parents: tuple[uuid.UUID, ...]) -> Session:
+    s = Session.from_user_message("x")
+    LineageRecorder.stamp_new_session(
+        s,
+        parent_session_ids=parents,
+        lineage_operator="t",
+        lineage_kind=LineageKind.OP_FORK,
+        lineage_extras=(("trace", "demo"),),
+    )
+    return s
+
+
+def test_session_to_jsonl_row_has_expected_keys() -> None:
+    p = uuid.uuid4()
+    s = _stamped((p,))
+    row = session_to_jsonl_row(s)
+    assert row["id"] == str(s.id)
+    assert row["parent_session_ids"] == [str(p)]
+    assert row["lineage_operator"] == "t"
+    assert row["lineage_kind"] == LineageKind.OP_FORK.value
+    assert row["lineage_extras"] == [["trace", "demo"]]
+    assert row["chunk_count"] == 1
+    assert row["cumulative_usage"] is None
+
+
+def test_export_jsonl_string_roundtrip() -> None:
+    a = _stamped(())
+    b = _stamped((a.id,))
+    text = export_jsonl_string([a, b])
+    assert text.endswith("\n")
+    lines = [ln for ln in text.split("\n") if ln]
+    assert len(lines) == 2
+    parsed = [json.loads(ln) for ln in lines]
+    assert parsed[0]["id"] == str(a.id)
+    assert parsed[1]["parent_session_ids"] == [str(a.id)]
+
+
+def test_export_jsonl_writes_file(tmp_path: Path) -> None:
+    a = _stamped(())
+    out = tmp_path / "nested" / "lineage.jsonl"
+    export_jsonl([a], out)
+    assert out.is_file()
+    assert json.loads(out.read_text(encoding="utf-8").strip())["id"] == str(a.id)
+
+
+def test_export_journal_jsonl_via_registry(tmp_path: Path) -> None:
+    """Journal collects visited ids; exporter resolves them via the registry."""
+    reg = session_registry()
+    with lineage_journal_tracking() as journal:
+        a = _stamped(())
+        b = _stamped((a.id,))
+        reg.register(a)
+        reg.register(b)
+
+    out = tmp_path / "graph.jsonl"
+    export_journal_jsonl(journal, out)
+    rows = [
+        json.loads(ln)
+        for ln in out.read_text(encoding="utf-8").splitlines()
+        if ln
+    ]
+    # journal.visit_order order should be preserved
+    assert [r["id"] for r in rows] == [str(uid) for uid in journal.visit_order]
+
+
+def test_export_journal_jsonl_skip_unknown(tmp_path: Path) -> None:
+    """Sessions not in the registry are silently skipped by default."""
+    j = LineageJournal(visit_order=[uuid.uuid4(), uuid.uuid4()])
+    out = tmp_path / "graph.jsonl"
+    export_journal_jsonl(j, out)
+    assert out.read_text(encoding="utf-8") == ""
+
+
+def test_lineage_extras_coerces_non_jsonable_values() -> None:
+    """Non-JSON values in lineage_extras must not break the export."""
+    s = Session.from_user_message("x")
+    # Use a non-serializable extras value (a set) - exporter should coerce.
+    LineageRecorder.stamp_new_session(
+        s,
+        parent_session_ids=(),
+        lineage_operator="t",
+        lineage_kind=LineageKind.LEAF_USER,
+        lineage_extras=(("weird", {1, 2}),),
+    )
+    text = export_jsonl_string([s])
+    row = json.loads(text.strip())
+    # value coerced to str representation
+    assert isinstance(row["lineage_extras"][0][1], str)

--- a/tests/session/test_lineage_graph_unit.py
+++ b/tests/session/test_lineage_graph_unit.py
@@ -103,3 +103,45 @@ def test_lineage_recorder_stamps_when_on() -> None:
     assert s.lineage_operator == "run_session_loop"
     assert s.lineage_kind == LineageKind.OP_SESSION_LOOP
     assert s.lineage_extras == (("k", 1),)
+
+
+def test_lineage_journal_yields_readable_after_exit() -> None:
+    """``lineage_journal_tracking`` must yield a journal whose ``visit_order``
+    contains every session created inside the block, and remain readable
+    after the context manager exits."""
+    from rath.session.graph.recording import lineage_journal_tracking
+
+    with lineage_journal_tracking() as journal:
+        a = Session.from_user_message("alpha")
+        LineageRecorder.stamp_new_session(
+            a,
+            parent_session_ids=(),
+            lineage_operator="test",
+            lineage_kind=LineageKind.LEAF_USER,
+        )
+        forked = a.fork()  # stamp via Session.fork
+        del forked
+
+    assert len(journal.visit_order) == 2
+    assert journal.visit_order[0] == a.id
+
+
+def test_lineage_journal_external_journal_is_mutated_in_place() -> None:
+    """Passing in a journal must reuse it: caller-owned reference sees updates."""
+    from rath.session.graph.recording import (
+        LineageJournal,
+        lineage_journal_tracking,
+    )
+
+    j = LineageJournal()
+    with lineage_journal_tracking(journal=j) as yielded:
+        assert yielded is j
+        s = Session.from_user_message("x")
+        LineageRecorder.stamp_new_session(
+            s,
+            parent_session_ids=(),
+            lineage_operator="t",
+            lineage_kind=LineageKind.LEAF_USER,
+        )
+
+    assert j.visit_order == [s.id]

--- a/tests/session/test_run_session_loop_edges.py
+++ b/tests/session/test_run_session_loop_edges.py
@@ -352,3 +352,34 @@ def test_default_executor_requires_provider_api_key() -> None:
                 agent.agent_session,
                 agent_provider=agent.provider,
             )
+
+
+def test_max_tool_rounds_truncation_emits_warning_and_lineage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A loop that keeps requesting tool calls past max_tool_rounds must log a
+    warning and stamp ('loop.truncated', True) in lineage_extras, so callers
+    can detect the dangling tool_result tail without diffing chunk rows."""
+    import logging
+
+    scripted = [_write_tool_response(f"tc{i}") for i in range(5)]
+    executor = ScriptedSessionLoopExecutor(scripted)
+    agent = AgentParam(Session.from_agent_prompt("sys"), Provider())
+    backend = get("local")
+
+    with backend.open() as sb:
+        user = Session.from_user_message("trigger loop budget").with_sandbox(sb)
+        with caplog.at_level(logging.WARNING, logger="rath.session.loop"):
+            out = run_session_loop(
+                user,
+                agent.agent_session,
+                agent_provider=agent.provider,
+                executor=executor,
+                max_tool_rounds=2,
+            )
+
+    assert ("loop.truncated", True) in out.lineage_extras
+    assert any("max_tool_rounds" in rec.message for rec in caplog.records)
+    # Last row should still be a tool_result (the symptom this warning
+    # exists to flag).
+    assert out.chunk_table.rows[-1].kind == ChunkKind.TOOL_RESULT

--- a/tests/session/test_run_session_loop_edges.py
+++ b/tests/session/test_run_session_loop_edges.py
@@ -338,7 +338,14 @@ def test_dispatch_exception_surfaces_in_tool_chunk() -> None:
     assert "RuntimeError" in payload.get("message", "")
 
 
-def test_default_executor_requires_provider_api_key() -> None:
+def test_default_executor_requires_api_key_somewhere(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no Provider.api_key and no env fallback, the default executor must
+    raise from the client (not from a redundant pre-check in the loop)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_API_KEY", raising=False)
     backend = get("local")
     agent = AgentParam(
         Session.from_agent_prompt("sys"),
@@ -346,7 +353,7 @@ def test_default_executor_requires_provider_api_key() -> None:
     )
     with backend.open() as sb:
         user = Session.from_user_message("x").with_sandbox(sb)
-        with pytest.raises(ValueError, match="agent_provider.api_key"):
+        with pytest.raises(ValueError, match="No API key found"):
             run_session_loop(
                 user,
                 agent.agent_session,

--- a/tests/session/test_run_session_loop_local.py
+++ b/tests/session/test_run_session_loop_local.py
@@ -159,6 +159,39 @@ def test_run_session_compress_chunk_print_hook_called() -> None:
     )
 
 
+def test_run_session_compress_without_sandbox() -> None:
+    """compress must accept a user_session that never called .to(...)."""
+    from rath.session import run_session_compress
+
+    scripted = RathLLMChatResponse(
+        id="c-no-sb",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="stop",
+                message=RathLLMAssistantMessage(content="short summary"),
+            ),
+        ),
+        created=10,
+        model="scripted",
+    )
+    executor = ScriptedSessionLoopExecutor([scripted])
+    user = Session.from_user_message("Some long transcript.")
+    agent_sess = Session.from_agent_prompt("You compress transcripts.")
+
+    out = run_session_compress(
+        user,
+        agent_sess,
+        agent_provider=Provider(api_key="k", model="scripted"),
+        executor=executor,
+        register_sessions=False,
+    )
+
+    assert out.sandbox is None
+    assert out.sandbox_backend is None
+    assert "short summary" in out.chunk_table.rows[0].payload.get("content", "")
+
+
 def test_run_session_loop_write_file_via_tool_then_stop() -> None:
     body = {"path": "_rath_loop_probe.txt", "content": "LOCAL_SCRIPTED_MARKER"}
     arg_str = json.dumps(body)

--- a/tests/session/test_token_budget.py
+++ b/tests/session/test_token_budget.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 
 from rath.backend import get
 from rath.flow.agent_param import AgentParam, Provider
+from rath.flow.tool import FlowToolCall
 from rath.llm import (
     BudgetExceededError,
     RathLLMAssistantMessage,
     RathLLMChatChoice,
     RathLLMChatResponse,
     RathLLMTokenUsage,
+    RathLLMToolCallFunction,
+    RathLLMToolCallPart,
 )
 from rath.session import Session, run_session_loop, session_registry
 from tests.session.scripted_loop_executor import ScriptedSessionLoopExecutor
@@ -149,6 +155,149 @@ def test_budget_callback_raising_aborts_loop() -> None:
                 agent_provider=agent.provider,
                 executor=executor,
             )
+
+
+class _NoopTool(FlowToolCall):
+    """Trivial FlowToolCall for budget tests; no sandbox interaction."""
+
+    @property
+    def name(self) -> str:
+        return "noop"
+
+    @property
+    def description(self) -> str | None:
+        return "noop"
+
+    @property
+    def parameters(self) -> Mapping[str, Any]:
+        return {"type": "object", "properties": {"x": {"type": "string"}}}
+
+    def __call__(self, session: Session, arguments: Mapping[str, Any]) -> dict[str, bool]:
+        del session, arguments
+        return {"ok": True}
+
+
+def _tool_call_response(
+    tcid: str, *, prompt: int, completion: int
+) -> RathLLMChatResponse:
+    """Tool-call response carrying usage, so the loop runs another round."""
+    body = {"x": tcid}
+    return RathLLMChatResponse(
+        id=f"budget-tc-{tcid}",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="tool_calls",
+                message=RathLLMAssistantMessage(
+                    tool_calls=(
+                        RathLLMToolCallPart(
+                            id=tcid,
+                            type="function",
+                            function=RathLLMToolCallFunction(
+                                name="noop",
+                                arguments=json.dumps(body),
+                                arguments_parsed=body,
+                                arguments_parse_error=False,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        created=0,
+        model="scripted",
+        usage=RathLLMTokenUsage(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+        ),
+    )
+
+
+def test_budget_callback_fires_only_on_first_crossing() -> None:
+    """Across a multi-round tool-calling loop, ``on_budget_exceeded`` must fire
+    exactly once even if cumulative usage stays above the cap for every
+    subsequent completion (the docstring contract: latched per session).
+    """
+    seen: list[int] = []
+
+    def _cb(_sess: object, usage: RathLLMTokenUsage) -> None:
+        seen.append(usage.total_tokens)
+
+    noop = _NoopTool()
+
+    # Round 1: 60 tokens (still under 100 cap).
+    # Round 2: +60 = 120 (first crossing — fires).
+    # Round 3: +60 = 180 (already above — must NOT re-fire).
+    # Round 4: +5 = 185, stop. (also must NOT re-fire).
+    executor = ScriptedSessionLoopExecutor(
+        [
+            _tool_call_response("tc1", prompt=30, completion=30),
+            _tool_call_response("tc2", prompt=30, completion=30),
+            _tool_call_response("tc3", prompt=30, completion=30),
+            _stop_response(prompt=3, completion=2),
+        ]
+    )
+    agent = AgentParam(
+        Session.from_agent_prompt("sys"),
+        Provider(budget_total_tokens=100, on_budget_exceeded=_cb),
+    )
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        out = run_session_loop(
+            user,
+            agent.agent_session,
+            agent_provider=agent.provider,
+            tools=[noop],
+            executor=executor,
+        )
+
+    assert len(seen) == 1, f"callback fired {len(seen)}x, want exactly 1"
+    assert seen[0] == 120, (
+        "callback should fire on the first round that pushes total past the cap"
+    )
+    assert out.cumulative_usage is not None
+    assert out.cumulative_usage.total_tokens == 185
+
+
+def test_budget_warning_emits_only_on_first_crossing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same latch behavior when no callback is set: warn once, not per round."""
+
+    noop = _NoopTool()
+
+    executor = ScriptedSessionLoopExecutor(
+        [
+            _tool_call_response("tc1", prompt=80, completion=40),
+            _tool_call_response("tc2", prompt=80, completion=40),
+            _stop_response(prompt=10, completion=10),
+        ]
+    )
+    agent = AgentParam(
+        Session.from_agent_prompt("sys"),
+        Provider(budget_total_tokens=100),
+    )
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        with caplog.at_level(logging.WARNING, logger="rath.session.loop"):
+            run_session_loop(
+                user,
+                agent.agent_session,
+                agent_provider=agent.provider,
+                tools=[noop],
+                executor=executor,
+            )
+
+    budget_warnings = [
+        rec for rec in caplog.records if "budget_total_tokens" in rec.message
+    ]
+    assert len(budget_warnings) == 1, (
+        f"expected exactly one budget warning across {len(executor._queue) + 3} "
+        f"completions, got {len(budget_warnings)}"
+    )
 
 
 def test_budget_without_callback_emits_warning(

--- a/tests/session/test_token_budget.py
+++ b/tests/session/test_token_budget.py
@@ -1,0 +1,177 @@
+"""Token usage accumulation and budget guard for the session loop."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from rath.backend import get
+from rath.flow.agent_param import AgentParam, Provider
+from rath.llm import (
+    BudgetExceededError,
+    RathLLMAssistantMessage,
+    RathLLMChatChoice,
+    RathLLMChatResponse,
+    RathLLMTokenUsage,
+)
+from rath.session import Session, run_session_loop, session_registry
+from tests.session.scripted_loop_executor import ScriptedSessionLoopExecutor
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> None:
+    yield
+    session_registry().set_active(None)
+
+
+def _stop_response(*, prompt: int, completion: int) -> RathLLMChatResponse:
+    return RathLLMChatResponse(
+        id="usage-test",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="stop",
+                message=RathLLMAssistantMessage(content="ok"),
+            ),
+        ),
+        created=1,
+        model="scripted",
+        usage=RathLLMTokenUsage(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+        ),
+    )
+
+
+def test_cumulative_usage_starts_none_and_accumulates() -> None:
+    """One scripted completion with usage produces a Session.cumulative_usage."""
+    executor = ScriptedSessionLoopExecutor([_stop_response(prompt=10, completion=20)])
+    agent = AgentParam(Session.from_agent_prompt("sys"), Provider())
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        out = run_session_loop(
+            user,
+            agent.agent_session,
+            agent_provider=agent.provider,
+            executor=executor,
+        )
+    assert out.cumulative_usage is not None
+    assert out.cumulative_usage.prompt_tokens == 10
+    assert out.cumulative_usage.completion_tokens == 20
+    assert out.cumulative_usage.total_tokens == 30
+
+
+def test_usage_remains_none_when_provider_reports_no_usage() -> None:
+    no_usage = RathLLMChatResponse(
+        id="x",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="stop",
+                message=RathLLMAssistantMessage(content="ok"),
+            ),
+        ),
+        created=1,
+        model="scripted",
+        usage=None,
+    )
+    executor = ScriptedSessionLoopExecutor([no_usage])
+    agent = AgentParam(Session.from_agent_prompt("sys"), Provider())
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        out = run_session_loop(
+            user,
+            agent.agent_session,
+            agent_provider=agent.provider,
+            executor=executor,
+        )
+    assert out.cumulative_usage is None
+
+
+def test_budget_exceeded_invokes_callback() -> None:
+    """Provider.on_budget_exceeded is called once total_tokens crosses the cap."""
+    seen: list[tuple[object, RathLLMTokenUsage]] = []
+
+    def _cb(sess: object, usage: RathLLMTokenUsage) -> None:
+        seen.append((sess, usage))
+
+    executor = ScriptedSessionLoopExecutor([_stop_response(prompt=100, completion=50)])
+    agent = AgentParam(
+        Session.from_agent_prompt("sys"),
+        Provider(budget_total_tokens=100, on_budget_exceeded=_cb),
+    )
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        out = run_session_loop(
+            user,
+            agent.agent_session,
+            agent_provider=agent.provider,
+            executor=executor,
+        )
+    assert len(seen) == 1
+    cb_session, cb_usage = seen[0]
+    assert cb_session is out
+    assert cb_usage.total_tokens == 150
+
+
+def test_budget_callback_raising_aborts_loop() -> None:
+    """Raising BudgetExceededError from the callback aborts run_session_loop."""
+
+    def _hard_stop(sess: object, usage: RathLLMTokenUsage) -> None:
+        raise BudgetExceededError(
+            f"hit cap; cumulative={usage.total_tokens}",
+        )
+
+    # First response triggers the budget; a second response would otherwise
+    # be consumed if the loop continued.
+    executor = ScriptedSessionLoopExecutor(
+        [
+            _stop_response(prompt=200, completion=50),
+            _stop_response(prompt=999, completion=999),
+        ]
+    )
+    agent = AgentParam(
+        Session.from_agent_prompt("sys"),
+        Provider(budget_total_tokens=100, on_budget_exceeded=_hard_stop),
+    )
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        with pytest.raises(BudgetExceededError, match="hit cap"):
+            run_session_loop(
+                user,
+                agent.agent_session,
+                agent_provider=agent.provider,
+                executor=executor,
+            )
+
+
+def test_budget_without_callback_emits_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No callback set: still warn so the overrun is at least visible."""
+    executor = ScriptedSessionLoopExecutor([_stop_response(prompt=200, completion=0)])
+    agent = AgentParam(
+        Session.from_agent_prompt("sys"),
+        Provider(budget_total_tokens=100),
+    )
+    backend = get("local")
+    with backend.open() as sb:
+        user = Session.from_user_message("hi").with_sandbox(sb)
+        with caplog.at_level(logging.WARNING, logger="rath.session.loop"):
+            out = run_session_loop(
+                user,
+                agent.agent_session,
+                agent_provider=agent.provider,
+                executor=executor,
+            )
+
+    assert out.cumulative_usage is not None
+    assert any(
+        "budget_total_tokens" in rec.message for rec in caplog.records
+    )

--- a/tests/test_dotenv_autoload.py
+++ b/tests/test_dotenv_autoload.py
@@ -1,0 +1,64 @@
+"""Auto-load of a project ``.env`` from :mod:`rath.__init__`."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rath import _load_project_dotenv
+
+
+def test_loads_env_from_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A ``.env`` in the current working directory is picked up."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=loaded-from-dotenv\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RATH_TEST_AUTOLOAD_KEY", raising=False)
+    monkeypatch.delenv("RATH_SKIP_DOTENV", raising=False)
+
+    _load_project_dotenv()
+
+    assert os.environ.get("RATH_TEST_AUTOLOAD_KEY") == "loaded-from-dotenv"
+
+
+def test_does_not_override_process_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Process env wins over ``.env`` (.env fills gaps, not overrides)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=from-dotenv\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RATH_TEST_AUTOLOAD_KEY", "from-process")
+    monkeypatch.delenv("RATH_SKIP_DOTENV", raising=False)
+
+    _load_project_dotenv()
+
+    assert os.environ.get("RATH_TEST_AUTOLOAD_KEY") == "from-process"
+
+
+def test_skip_env_disables_autoload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``RATH_SKIP_DOTENV=1`` must bypass loading entirely."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "RATH_TEST_AUTOLOAD_KEY=should-not-load\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RATH_TEST_AUTOLOAD_KEY", raising=False)
+    monkeypatch.setenv("RATH_SKIP_DOTENV", "1")
+
+    _load_project_dotenv()
+
+    assert "RATH_TEST_AUTOLOAD_KEY" not in os.environ

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,113 @@
+"""Unit tests for :mod:`rath.llm._retry`."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterator
+
+import httpx
+import pytest
+
+from openai import APIConnectionError, RateLimitError
+
+from rath.llm._retry import retry_with_backoff
+
+
+def _fake_rate_limit() -> RateLimitError:
+    """Build a RateLimitError without going through the OpenAI SDK constructor.
+
+    The SDK's exception classes accept ``message``/``response``/``body`` so we
+    construct a minimal response. Older / newer SDK versions accept slightly
+    different shapes - this signature is stable across openai 1.x.
+    """
+    resp = httpx.Response(429, request=httpx.Request("POST", "https://x"))
+    return RateLimitError(message="rate limited", response=resp, body=None)
+
+
+def _fake_connection_error() -> APIConnectionError:
+    return APIConnectionError(request=httpx.Request("POST", "https://x"))
+
+
+def _scripted(seq: list[BaseException | str]) -> Callable[[], str]:
+    """Build a thunk that yields the next exception-or-value on each call."""
+    it: Iterator[BaseException | str] = iter(seq)
+
+    def _call() -> str:
+        x = next(it)
+        if isinstance(x, BaseException):
+            raise x
+        return x
+
+    return _call
+
+
+def test_retries_on_rate_limit_and_eventually_succeeds() -> None:
+    sleeps: list[float] = []
+    call = _scripted([_fake_rate_limit(), _fake_rate_limit(), "ok"])
+    result = retry_with_backoff(
+        call,
+        max_attempts=5,
+        base_seconds=0.01,
+        jitter=False,
+        sleep=sleeps.append,
+    )
+    assert result == "ok"
+    assert len(sleeps) == 2  # two backoffs before the third successful attempt
+
+
+def test_retries_on_api_connection_error() -> None:
+    call = _scripted([_fake_connection_error(), "recovered"])
+    sleeps: list[float] = []
+    out = retry_with_backoff(
+        call,
+        max_attempts=3,
+        base_seconds=0.01,
+        jitter=False,
+        sleep=sleeps.append,
+    )
+    assert out == "recovered"
+
+
+def test_gives_up_after_max_attempts() -> None:
+    sleeps: list[float] = []
+    call = _scripted([_fake_rate_limit(), _fake_rate_limit(), _fake_rate_limit()])
+    with pytest.raises(RateLimitError):
+        retry_with_backoff(
+            call,
+            max_attempts=3,
+            base_seconds=0.01,
+            jitter=False,
+            sleep=sleeps.append,
+        )
+    # 3 attempts means 2 backoffs (no sleep after the final failure).
+    assert len(sleeps) == 2
+
+
+def test_non_retryable_propagates_immediately() -> None:
+    sleeps: list[float] = []
+
+    def call() -> str:
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError, match="not retryable"):
+        retry_with_backoff(
+            call,
+            max_attempts=4,
+            base_seconds=0.01,
+            jitter=False,
+            sleep=sleeps.append,
+        )
+    assert sleeps == []  # never slept; not retryable
+
+
+def test_backoff_grows_exponentially() -> None:
+    sleeps: list[float] = []
+    call = _scripted([_fake_rate_limit(), _fake_rate_limit(), _fake_rate_limit(), "ok"])
+    retry_with_backoff(
+        call,
+        max_attempts=4,
+        base_seconds=0.1,
+        jitter=False,
+        sleep=sleeps.append,
+    )
+    # No jitter: 0.1, 0.2, 0.4
+    assert sleeps == [pytest.approx(0.1), pytest.approx(0.2), pytest.approx(0.4)]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -793,6 +793,7 @@ source = { editable = "." }
 dependencies = [
     { name = "openai" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 
 [package.optional-dependencies]
@@ -824,6 +825,7 @@ requires-dist = [
     { name = "opensandbox-code-interpreter", marker = "extra == 'opensandbox'", specifier = ">=0.1.2" },
     { name = "opensandbox-server", marker = "extra == 'opensandbox'", specifier = ">=0.1.12" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 provides-extras = ["opensandbox"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,66 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -201,6 +261,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -345,6 +451,15 @@ socks = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -457,6 +572,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
     { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -642,6 +784,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -797,6 +964,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
+]
 opensandbox = [
     { name = "opensandbox" },
     { name = "opensandbox-code-interpreter" },
@@ -820,6 +990,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opensandbox", marker = "extra == 'opensandbox'", specifier = ">=0.1.7" },
     { name = "opensandbox-code-interpreter", marker = "extra == 'opensandbox'", specifier = ">=0.1.2" },
@@ -827,7 +998,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
-provides-extras = ["opensandbox"]
+provides-extras = ["opensandbox", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -925,6 +1096,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1082,6 +1262,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,6 +1315,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
@@ -1198,6 +1404,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1232,6 +1452,99 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1424,6 +1737,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/13/3cafb96bceb02949f265bbdf1cbcea2810271ae709e4aa35e980f90c07fd/sse_starlette-3.4.3.tar.gz", hash = "sha256:a7f6d87cf482cf38b911c31075811c7f8b4efbada8ac9d5199a8e239fed513c9", size = 35247, upload-time = "2026-05-11T17:23:41.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/a4/c888212b19dd432110d4a78dbc5e6c1bc7476e5fff2f2df2ea9f298b0003/sse_starlette-3.4.3-py3-none-any.whl", hash = "sha256:bf8a90d76192062f01b55095593606bfc7edd0e3ad481339a6e16e7890bc9367", size = 16514, upload-time = "2026-05-11T17:23:40.352Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This is **PR-2 of 3**. Three medium-size, independent features. Each has
its own optional extra (or zero new deps), its own test file, and a
runnable example. None touches `run_session_loop`'s message-assembly
logic - they all plug in through Provider fields or new pure modules.

| # | Commit | What |
|---|---|---|
| 1 | `feat(llm): retry transient API errors, aggregate token usage, add budget guard` | Three concerns share the same per-completion hook so they're rolled together. **Retry**: hand-written `rath.llm._retry.retry_with_backoff` (no new dep) wraps `RathOpenAIChatClient.complete` for `RateLimitError / APIConnectionError / APITimeoutError / InternalServerError`; defaults 4 attempts / 0.5s base / 30s cap / jitter, overridable via `Provider.retry_max_attempts` and `Provider.retry_base_seconds`. **Token aggregation**: `Session` gains `cumulative_usage: RathLLMTokenUsage | None`; `add_usage()` is a pure helper exported from `rath.llm`. `run_session_loop` and `run_session_compress` fold each completion's usage into the output session. `fork()` / `detach()` reset to zero (derived sessions start fresh). **Budget guard**: `Provider.budget_total_tokens` + `Provider.on_budget_exceeded(session, usage)` callback. Loop checks after each completion; with no callback the loop just logs a warning, with a callback the user can `raise BudgetExceededError` to abort cleanly. |
| 2 | `feat(graph): JSONL lineage exporter for sessions and journals` | New module `rath.session.graph.export` with `session_to_jsonl_row`, `export_jsonl_string`, `export_jsonl(path)`, `export_journal_jsonl(journal, path)`. One Session per line; edges are implied by `parent_session_ids` so the output is jq-friendly and Mermaid-convertible. `export_journal_jsonl` resolves visit_order through the global `session_registry` and silently skips missing ids (pass `skip_unknown=False` to raise instead). Non-JSON values in `lineage_extras` are coerced to `str()` so one exotic key doesn't break the whole dump. `example/lineage_export.py` builds a small fork/detach graph and writes it. |
| 3 | `feat(tool): MCP stdio adapter` | New optional extra `[mcp]` (`mcp>=1.0.0`). `rath.flow.tool.mcp_adapter` exposes `MCPClient` (sync wrapper around `stdio_client` + `ClientSession`), `MCPToolCall(FlowToolCall)`, and a `mcp_tools_from_server(command, args=..., env=...)` factory. Each `list_tools` / `call_tool` opens a fresh subprocess - trivially correct under anyio cancellation scopes; per-call cost is dominated by LLM latency anyway. Only stdio transport in this PR; SSE / HTTP can plug in behind the same `MCPClient` interface later. `example/mcp_tool_usage.py` plus a tiny in-tree `example/_demo_echo_server.py` give a no-external-deps round-trip. |

## Stack

- #1 — bug fixes + Agent/.env API. **Merge first.**
- **#PR-2** (this PR) — *Depends on #1.*
- PR-3 — pluggable LLM clients (Protocol + Anthropic + streaming + async).
  *Depends on this PR.*

This PR's diff currently includes PR-1's commits because GitHub doesn't
support cross-fork stacked PR bases. Once #1 lands in `main`, this
PR will rebase to just its own three commits.

## Test plan

- [x] `uv run flake8 src tests example` — clean
- [x] `uv run mypy src` — clean (48 source files w/ mcp installed)
- [x] `uv run pytest -q` — 275 passed, 52 skipped (245 from PR-1 + 30 new)
- [x] `uv sync --extra mcp` — installs cleanly
- [x] Smoke: `example/lineage_export.py` writes a 4-row JSONL
- [x] Smoke: `example/mcp_tool_usage.py` round-trips against the in-tree demo server
- [x] Budget guard: scripted overrun fires the callback exactly once; raising
      `BudgetExceededError` from the callback aborts the loop

## Notes for the maintainer

- The `[mcp]` extra pulls a fair number of transitive deps (anyio + uvicorn
  + starlette etc.). Keeping it strictly optional was deliberate.
- `mcp_tools_from_server` opens a subprocess **per call**. For high-call-volume
  tools, a long-lived `ClientSession` worker on the dedicated asyncio loop is a
  natural follow-up; the public surface won't change.

## Breaking changes

None. New Provider fields are all optional with `None` defaults. `Session`'s
new `cumulative_usage` is a new field; existing constructors keep working.
