### PR TITLE
ci: add GitHub Actions CI workflows and pre-commit hooks

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+permissions:
+  contents: read
+
+jobs:
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - run: uv build

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,34 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'README*.md'
+      - 'CONTRIBUTING.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'README*.md'
+      - 'CONTRIBUTING.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - run: uv sync --group dev --group docs --frozen
+      - run: uv run sphinx-build -M html docs/source docs/_build -W

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,50 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'example/**'
+      - 'pyproject.toml'
+      - 'mypy.ini'
+      - 'uv.lock'
+      - '.python-version'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'example/**'
+      - 'pyproject.toml'
+      - 'mypy.ini'
+      - 'uv.lock'
+      - '.python-version'
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - run: uv sync --dev --frozen
+      - run: uv run ruff check src tests example
+      - run: uv run ruff format --check src tests example
+
+  mypy:
+    name: MyPy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - run: uv sync --dev --frozen
+      - run: uv run mypy --no-incremental

--- a/.github/workflows/ci-shellcheck.yml
+++ b/.github/workflows/ci-shellcheck.yml
@@ -1,0 +1,29 @@
+name: ShellCheck
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/*.sh'
+      - '.shellcheckrc'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/*.sh'
+      - '.shellcheckrc'
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './scripts'
+        env:
+          SHELLCHECK_OPTS: -x

--- a/.github/workflows/ci-test-fast.yml
+++ b/.github/workflows/ci-test-fast.yml
@@ -1,0 +1,42 @@
+name: Test Fast
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'example/**'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+      - 'uv.lock'
+      - '.python-version'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'example/**'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+      - 'uv.lock'
+      - '.python-version'
+
+permissions:
+  contents: read
+
+jobs:
+  test-fast:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --dev --frozen
+      - run: uv run pytest -m 'not opensandbox and not live_llm'

--- a/.github/workflows/ci-test-opensandbox.yml
+++ b/.github/workflows/ci-test-opensandbox.yml
@@ -1,0 +1,61 @@
+name: Test OpenSandbox
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/rath/backend/**'
+      - 'src/rath/session/**'
+      - 'tests/backends/**'
+      - 'tests/conformance/**'
+      - 'tests/session/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/rath/backend/**'
+      - 'src/rath/session/**'
+      - 'tests/backends/**'
+      - 'tests/conformance/**'
+      - 'tests/session/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+permissions:
+  contents: read
+
+jobs:
+  test-opensandbox:
+    name: pytest (opensandbox)
+    runs-on: ubuntu-latest
+    # OpenSandbox tests require a running server; allow failure in PRs
+    # until the CI environment is verified stable.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - name: Install OpenSandbox dependencies
+        run: uv sync --extra opensandbox --frozen
+      - name: Init OpenSandbox config
+        run: |
+          export OPENSANDBOX_INSECURE_SERVER=YES
+          uv run opensandbox-server init-config --example docker .sandbox.toml
+      - name: Start OpenSandbox server
+        run: |
+          export OPENSANDBOX_INSECURE_SERVER=YES
+          uv run opensandbox-server --config .sandbox.toml &
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8080/health >/dev/null 2>&1; then
+              echo "OpenSandbox server ready"
+              exit 0
+            fi
+            echo "Waiting for OpenSandbox server... ($i/30)"
+            sleep 2
+          done
+          echo "OpenSandbox server failed to start" >&2
+          exit 1
+      - name: Run OpenSandbox tests
+        run: uv run pytest -m opensandbox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: [-x]
+        types: [shell]
+        exclude: ".*\\.bat$"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+# Shellcheck configuration
+# https://github.com/koalaman/shellcheck/wiki/Directive
+
+# Enable all checks by default
+enable=all
+
+# Disable specific checks
+# SC1091: Not following sourced files (external scripts)
+disable=SC1091


### PR DESCRIPTION
  ## Summary

  Add CI/CD pipelines via GitHub Actions and a pre-commit configuration for contributor   convenience.

  ### Added workflows

  | Workflow | Trigger | Purpose |
  |---|---|---|
  | `ci-build.yml` | push/PR touching `src/`, `pyproject.toml`, `uv.lock` | Build the wheel with `uv build` |
  | `ci-lint.yml` | push/PR touching source/test/example/config files | Run `ruff check`, `ruff  format --check`, and `mypy` |
  | `ci-test-fast.yml` | push/PR touching source/test/example/config files | Run `pytest -m 'not opensandbox and not live_llm'` on Python 3.10–3.13 |
  | `ci-test-opensandbox.yml` | push/PR touching backend/session/test files | Run `pytest -m opensandbox` against a live OpenSandbox server |
  | `ci-docs.yml` | push/PR touching `docs/`, README, config | Build Sphinx HTML with `-W` (warnings as errors) |
  | `ci-shellcheck.yml` | push/PR touching `scripts/*.sh` | Lint shell scripts via `ludeeus/action-shellcheck` |

  ### Added config files

  - `.pre-commit-config.yaml` — ruff (check + format) and shellcheck hooks
  - `.shellcheckrc` — enable all checks, disable `SC1091` (sourced files)

  ### Notes

  - The `ci-lint.yml` workflow references `ruff` and `ruff format`, so this PR depends on the   ruff-migration PR being merged first (or both can be coordinated together).
  - `ci-test-opensandbox.yml` uses `continue-on-error` on PRs since the OpenSandbox server  environment may not be fully stable in CI yet.