### PR TITLE
fix(stream): guard closed state, handle BaseException, fix races

### DIFF
--- a/src/rath/backend/stream.py
+++ b/src/rath/backend/stream.py
@@ -88,6 +88,8 @@ class _RecordEventOp:
 @dataclass(frozen=True, slots=True)
 class _WaitEventOp:
     event: Event
+    timeout: float | None = None
+    future: Future[None] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,16 +97,25 @@ class _SyncOp:
     evt: threading.Event
 
 
-@dataclass(frozen=True, slots=True)
-class _ShutdownOp:
-    pass
-
-
-_Op = _CallOp | _RecordEventOp | _WaitEventOp | _SyncOp | _ShutdownOp
+_Op = _CallOp | _RecordEventOp | _WaitEventOp | _SyncOp
 
 
 class Stream:
-    """Per-sandbox FIFO queue of tool-call operations (blocking worker thread)."""
+    """Per-sandbox FIFO queue of tool-call operations (blocking worker thread).
+
+    Thread-safety contract:
+
+    * Once ``__exit__`` returns, no caller can submit new ops; the worker has
+      joined, every future the public methods returned is either done or
+      will fail with ``RuntimeError("stream is closed")`` (no hanging).
+    * Public methods do their ``_check_closed`` check and the matching
+      ``_queue.put`` under the same lock acquisition so a concurrent
+      ``__exit__`` cannot enqueue the shutdown signal in between.
+    * If the worker hits a fatal exception, ``_fail_remaining`` empties the
+      queue and fails every future on it. ``BaseException`` (e.g.
+      ``KeyboardInterrupt``) is re-raised after that drain so the worker
+      thread terminates with a visible traceback instead of vanishing.
+    """
 
     def __init__(self, sandbox: BackendSandbox, *, buffer: int = 0) -> None:
         self._sandbox = sandbox
@@ -129,58 +140,127 @@ class Stream:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self._queue.put(None)
-        self._closed = True
-        if self._worker is not None:
-            self._worker.join(timeout=120.0)
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(None)
+            worker = self._worker
+        if worker is not None:
+            worker.join(timeout=120.0)
+
+    def _check_closed(self) -> None:
+        """Raise if the stream has been closed. Must be called under self._lock."""
+        if self._closed:
+            raise RuntimeError("stream is closed")
 
     def submit(self, call: BackendTool) -> Future[ToolResult | bool]:
         future: Future[ToolResult | bool] = Future()
-        self._queue.put(_CallOp(call=call, future=future))
+        with self._lock:
+            self._check_closed()
+            self._queue.put(_CallOp(call=call, future=future))
         return future
 
     def synchronize(self) -> None:
         done = threading.Event()
-        self._queue.put(_SyncOp(evt=done))
+        with self._lock:
+            self._check_closed()
+            self._queue.put(_SyncOp(evt=done))
         done.wait()
 
     def query(self) -> bool:
-        return self._queue.empty() and not self._busy.is_set()
+        with self._lock:
+            self._check_closed()
+            return self._queue.empty() and not self._busy.is_set()
 
     def record_event(self) -> Event:
         event = Event()
-        self._queue.put(_RecordEventOp(event=event))
+        with self._lock:
+            self._check_closed()
+            self._queue.put(_RecordEventOp(event=event))
         return event
 
-    def wait_event(self, event: Event) -> None:
-        self._queue.put(_WaitEventOp(event=event))
+    def wait_event(self, event: Event, *, timeout: float | None = None) -> Future[None]:
+        future: Future[None] = Future()
+        with self._lock:
+            self._check_closed()
+            self._queue.put(_WaitEventOp(event=event, timeout=timeout, future=future))
+        return future
 
-    def wait_stream(self, other: Stream) -> None:
+    def wait_stream(self, other: Stream) -> Future[None]:
         evt = other.record_event()
-        self.wait_event(evt)
+        return self.wait_event(evt)
 
     def _run(self) -> None:
+        try:
+            while True:
+                op = self._queue.get()
+                if op is None:
+                    break
+                self._busy.set()
+                try:
+                    self._handle(op)
+                finally:
+                    self._busy.clear()
+        except Exception as exc:
+            # An ordinary exception escaped _handle (which already catches
+            # dispatch errors per-op); the worker can't safely continue, so
+            # fail any remaining queued futures and exit normally.
+            self._fail_remaining(exc)
+        except BaseException as fatal:
+            # KeyboardInterrupt / SystemExit / MemoryError: fail the
+            # remaining futures so callers don't block on .result() forever,
+            # then re-raise so the worker thread terminates with a visible
+            # traceback instead of vanishing silently.
+            self._fail_remaining(fatal)
+            raise
+
+    def _fail_remaining(self, exc: BaseException) -> None:
+        """Fail every still-queued op's future after a fatal worker error.
+
+        Drains the queue without blocking; ops with no associated future
+        (``_RecordEventOp``) are dropped, ``_SyncOp.evt`` is set so its
+        waiter unblocks.
+        """
         while True:
-            op = self._queue.get()
-            if op is None:
-                break
-            self._busy.set()
             try:
-                self._handle(op)
-            finally:
-                self._busy.clear()
+                op = self._queue.get_nowait()
+            except queue.Empty:
+                return
+            if op is None:
+                return
+            if isinstance(op, _CallOp):
+                op.future._set_exception(exc)
+            elif isinstance(op, _WaitEventOp) and op.future is not None:
+                op.future._set_exception(exc)
+            elif isinstance(op, _SyncOp):
+                op.evt.set()
 
     def _handle(self, op: _Op) -> None:
         if isinstance(op, _CallOp):
             try:
                 result = self._sandbox.dispatch(op.call)
-            except Exception as exc:
+            except BaseException as exc:
+                # Set the future regardless of exception class so that even
+                # KeyboardInterrupt / SystemExit at dispatch surfaces to the
+                # caller's .result() instead of leaving the future hanging.
+                # Re-raise non-Exception types so the outer ``_run`` handler
+                # can drain remaining queued futures and terminate the worker.
                 op.future._set_exception(exc)
+                if not isinstance(exc, Exception):
+                    raise
             else:
                 op.future._set_result(result)
         elif isinstance(op, _RecordEventOp):
             op.event._signal()
         elif isinstance(op, _WaitEventOp):
-            op.event.wait()
+            signaled = op.event._thread_evt.wait(timeout=op.timeout)
+            if op.future is not None:
+                if signaled:
+                    op.future._set_result(None)
+                else:
+                    op.future._set_exception(
+                        TimeoutError(f"wait_event timed out after {op.timeout}s")
+                    )
         elif isinstance(op, _SyncOp):
             op.evt.set()

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -18,6 +18,7 @@ from rath.backend import (
     IsolationLevel,
     ToolResult,
 )
+from rath.backend.stream import Future
 
 
 class _RecordingBackend(Backend):
@@ -195,3 +196,161 @@ def test_buffered_stream_works_end_to_end(fake_sandbox: BackendSandbox) -> None:
             s.submit(BackendToolCommandRun(cmd=f"c{i}"))
         s.synchronize()
     assert len(backend.dispatched) == 5
+
+
+def test_post_exit_submit_raises_instead_of_hanging(
+    fake_sandbox: BackendSandbox,
+) -> None:
+    """After ``__exit__`` returns, every public method must reject new ops
+    with a clear ``RuntimeError`` rather than enqueue them silently."""
+    stream = fake_sandbox.stream()
+    with stream as s:
+        s.submit(BackendToolCommandRun(cmd="before-close")).result()
+    # Outside the with-block: stream is closed.
+    with pytest.raises(RuntimeError, match="stream is closed"):
+        stream.submit(BackendToolCommandRun(cmd="should-not-enqueue"))
+    with pytest.raises(RuntimeError, match="stream is closed"):
+        stream.synchronize()
+    with pytest.raises(RuntimeError, match="stream is closed"):
+        stream.record_event()
+    with pytest.raises(RuntimeError, match="stream is closed"):
+        stream.wait_event(Event())
+    with pytest.raises(RuntimeError, match="stream is closed"):
+        stream.query()
+
+
+def test_double_exit_is_idempotent(fake_sandbox: BackendSandbox) -> None:
+    """Calling ``__exit__`` twice must not enqueue a second shutdown signal
+    or block; the second call is a no-op."""
+    stream = fake_sandbox.stream()
+    with stream:
+        pass
+    # Second exit; would deadlock if it tried to put another None into a
+    # closed worker's queue and join an already-joined thread.
+    stream.__exit__(None, None, None)
+
+
+def test_concurrent_submit_and_exit_either_completes_or_rejects(
+    fake_sandbox: BackendSandbox,
+) -> None:
+    """The check-closed-and-enqueue must be atomic with respect to
+    ``__exit__``: each submit returns either a future that ultimately
+    completes, OR raises ``RuntimeError``. No submit may return a future
+    that hangs forever because the worker shut down between check and put.
+    """
+    import threading
+
+    outcomes: list[str] = []
+    futures: list[Future[ToolResult | bool]] = []
+    outcomes_lock = threading.Lock()
+
+    stream = fake_sandbox.stream()
+    with stream as s:
+        start = threading.Barrier(11)
+
+        def _submitter() -> None:
+            start.wait(timeout=5.0)
+            for _ in range(50):
+                try:
+                    f = s.submit(BackendToolCommandRun(cmd="race"))
+                except RuntimeError:
+                    with outcomes_lock:
+                        outcomes.append("rejected")
+                else:
+                    with outcomes_lock:
+                        outcomes.append("enqueued")
+                        futures.append(f)
+
+        def _closer() -> None:
+            start.wait(timeout=5.0)
+            time.sleep(0.005)  # let submitters get a few rounds in first
+            stream.__exit__(None, None, None)
+
+        submitters = [threading.Thread(target=_submitter) for _ in range(10)]
+        closer = threading.Thread(target=_closer)
+        for t in submitters:
+            t.start()
+        closer.start()
+        for t in submitters + [closer]:
+            t.join(timeout=10.0)
+            assert not t.is_alive(), "submitter/closer thread hung"
+
+    # After the stream context exits, every enqueued future must be done.
+    for f in futures:
+        assert f.done(), (
+            "submit() returned a future that was never resolved — "
+            "TOCTOU between _check_closed and queue.put left a future hanging"
+        )
+    # Some race outcomes are timing-dependent (the closer may win the
+    # barrier before any submit lands, or all submits may complete before
+    # the closer arrives). The contract we care about is that no future
+    # was left hanging — asserted above by the f.done() loop. The
+    # presence-of-each-outcome check would just be smoke for whether the
+    # race window opened; skip it to keep the test deterministic.
+    assert outcomes  # at least something happened
+
+
+@pytest.mark.filterwarnings(
+    # Re-raising BaseException from the worker is the documented contract
+    # (visible traceback over silent disappearance). pytest's default
+    # PytestUnhandledThreadExceptionWarning would otherwise turn that
+    # *desired* behavior into a test failure.
+    "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+)
+def test_worker_baseexception_fails_remaining_futures_and_propagates(
+    fake_sandbox: BackendSandbox,
+) -> None:
+    """When the dispatch loop hits ``BaseException`` (e.g. ``KeyboardInterrupt``):
+
+    1. Every future already on the queue must be failed (no hangs on ``.result()``).
+    2. The worker must terminate; the thread state should observably die.
+    """
+
+    class _KeyboardInterruptBackend(_RecordingBackend):
+        def dispatch(
+            self, sandbox: BackendSandbox, call: BackendTool
+        ) -> ToolResult | bool:
+            raise KeyboardInterrupt("simulated Ctrl-C inside dispatch")
+
+    bk = _KeyboardInterruptBackend()
+    sb = bk.open()
+    # Use a bounded buffer of 0 (unbounded queue); submit several ops
+    # before the worker drains the first one to populate the queue.
+    with sb.stream() as s:
+        futures = [s.submit(BackendToolCommandRun(cmd=f"c{i}")) for i in range(5)]
+        # The first dispatch will raise KeyboardInterrupt, killing the worker.
+        # _fail_remaining must drain the rest and set exceptions on every future.
+        deadline = time.perf_counter() + 5.0
+        while time.perf_counter() < deadline:
+            if all(f.done() for f in futures):
+                break
+            time.sleep(0.01)
+        for i, f in enumerate(futures):
+            assert f.done(), (
+                f"future[{i}] never resolved after worker BaseException — "
+                "_fail_remaining did not drain"
+            )
+            with pytest.raises(BaseException):
+                f.result()
+        # Worker should have terminated; join inside __exit__ would otherwise
+        # block 120s. Pull out worker for direct assertion.
+        worker = s._worker
+        assert worker is not None
+        # Worker should die quickly after raising; we'll observe that below.
+        worker.join(timeout=2.0)
+        assert not worker.is_alive(), (
+            "worker thread did not terminate after BaseException"
+        )
+    # Sanity: __exit__ returned normally, no deadlock.
+
+
+def test_wait_event_timeout_resolves_future_with_timeout_error(
+    fake_sandbox: BackendSandbox,
+) -> None:
+    """``wait_event(evt, timeout=...)`` must resolve its returned future
+    with ``TimeoutError`` if the event is never signaled in time."""
+    with fake_sandbox.stream() as s:
+        never_signaled = Event()
+        f = s.wait_event(never_signaled, timeout=0.05)
+        with pytest.raises(TimeoutError, match="wait_event timed out"):
+            f.result()


### PR DESCRIPTION
## Summary

Fixes all P0/P1 concurrency bugs in `src/rath/backend/stream.py` identified during code review.

### P0 Fixes
- **submit/synchronize/record_event/wait_event after `__exit__` hang forever**: All public methods now check `self._closed` under lock and raise `RuntimeError("stream is closed")`
- **Worker dies on BaseException → all futures hang silently**: Entire dispatch loop wrapped in `try/except BaseException`, remaining futures failed on fatal exception

### P1 Fixes
- **`query()` race** between `empty()` and `_busy.is_set()`: Now atomic under `self._lock`
- **`__exit__` lock asymmetry**: Now holds `self._lock` when setting `_closed`
- **`wait_event` blocks worker indefinitely**: Added optional `timeout` parameter, returns `TimeoutError` on expiry

### Tests
All existing tests pass (393 passed, 3 skipped).