### PR TITLE
perf(config): cache ConfigStore.load() by mtime, fix atomic save race

### DIFF
--- a/src/rath/config/store.py
+++ b/src/rath/config/store.py
@@ -1,13 +1,16 @@
 """Load / mutate / save the on-disk OpenRath config.
 
-Single-process, infrequent-write semantics. No locking, no caching across
-processes. Atomic on save (tmp file + ``os.replace``) so a crashed write
-never leaves a half-written file.
+Single-process, infrequent-write semantics. Process-local mtime-based
+caching on read; threading lock + unique temp files on write for
+concurrent-write safety. Atomic on save (tmp file + ``os.replace``) so a
+crashed write never leaves a half-written file.
 """
 
 from __future__ import annotations
 
 import json
+import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -52,15 +55,73 @@ class ConfigStore:
     :attr:`config` directly; call :meth:`save` to persist.
     """
 
+    # Process-local cache: maps resolved path → ((mtime_ns, size), store).
+    # Mtime alone is insufficient on filesystems with second-level
+    # resolution (e.g. HFS+): two saves landing in the same second look
+    # identical via ``st_mtime_ns``. Pairing mtime with file size catches
+    # almost every same-second rewrite (any append/edit/replace that
+    # changes byte count). The residual same-mtime-same-size collision
+    # would require both writes to produce identical-length JSON within
+    # one second; for a config that holds API keys, base URLs, and
+    # provider lists, that's vanishingly rare. Within a single process
+    # this is moot anyway — ``save()`` invalidates the cache entry
+    # below, so a save-then-load pair always re-reads from disk.
+    _cache: dict[Path, tuple[tuple[int, int], "ConfigStore"]] = {}
+    _cache_lock = threading.Lock()
+
     def __init__(self, path: Path | None = None) -> None:
         self.path = (path or resolve_config_path()).resolve()
         self._raw_unknown: dict[str, Any] = {}
+        self._save_lock = threading.Lock()
         self._data: RathConfig = self._load_or_default()
 
     @classmethod
     def load(cls) -> "ConfigStore":
-        """Build a store from the resolved default path."""
-        return cls()
+        """Build a store from the resolved default path, with mtime caching.
+
+        Returns a cached instance when the config file's (mtime, size)
+        pair has not changed since the last read. This eliminates
+        redundant disk reads when callers (e.g. LLM clients) invoke
+        ``load()`` on every ``complete()`` call. The pair-based key
+        guards against HFS+-style 1-second mtime resolution: a rewrite
+        that lands in the same second as the previous one is still
+        detected as long as the file's size changed.
+        """
+        resolved = resolve_config_path().resolve()
+        current_stamp = cls._stat_stamp(resolved)
+
+        if current_stamp is not None:
+            with cls._cache_lock:
+                cached = cls._cache.get(resolved)
+                if cached is not None and cached[0] == current_stamp:
+                    return cached[1]
+
+        # Cache miss or stamp changed — rebuild
+        store = cls(resolved)
+
+        # Re-read stamp after load (the file we just parsed). We sample
+        # again because the load could have raced a writer; storing the
+        # post-load stamp is what makes the next cache hit valid.
+        post_stamp = cls._stat_stamp(resolved)
+        if post_stamp is not None:
+            with cls._cache_lock:
+                cls._cache[resolved] = (post_stamp, store)
+
+        return store
+
+    @staticmethod
+    def _stat_stamp(path: Path) -> tuple[int, int] | None:
+        """Return ``(mtime_ns, size)`` for the cache key, or ``None`` if missing.
+
+        ``None`` means "file doesn't exist (or we couldn't stat it)" —
+        callers must always rebuild and skip cache insertion in that
+        case, since there's nothing meaningful to key on.
+        """
+        try:
+            st = path.stat()
+        except OSError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
 
     @property
     def config(self) -> RathConfig:
@@ -72,13 +133,14 @@ class ConfigStore:
 
         Side-effects:
         - Creates parent directory if missing.
-        - Writes ``<path>.tmp`` then ``os.replace`` — durable on POSIX and
-          Windows.
+        - Writes a uniquely-named temp file then ``os.replace`` — durable
+          on POSIX and Windows, safe under concurrent writers.
         - ``chmod 600`` on POSIX so secrets are not world-readable.
         - Writes a deny-all ``.gitignore`` next to the config (idempotent).
         - When the config dir is the project-local ``./.openrath/``, also
           appends ``.openrath/`` to the surrounding project ``.gitignore``
           (idempotent; skipped when no project gitignore exists).
+        - Invalidates the process-local read cache for this path.
         """
         config_dir = self.path.parent
         ensure_config_dir_gitignore(config_dir)
@@ -87,10 +149,32 @@ class ConfigStore:
 
         payload = self._merged_payload()
         text = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=False)
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp.write_text(text + "\n", encoding="utf-8")
-        tmp.replace(self.path)
-        chmod_user_only(self.path)
+
+        with self._save_lock:
+            fd = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=config_dir,
+                prefix=".config_",
+                suffix=".tmp",
+                delete=False,
+            )
+            try:
+                tmp_path = Path(fd.name)
+                fd.write(text + "\n")
+                fd.flush()
+                fd.close()
+                tmp_path.replace(self.path)
+            except BaseException:
+                fd.close()
+                tmp_path = Path(fd.name)
+                tmp_path.unlink(missing_ok=True)
+                raise
+            chmod_user_only(self.path)
+
+            # Invalidate read cache so next load() picks up the new data
+            with type(self)._cache_lock:
+                type(self)._cache.pop(self.path, None)
 
     # --- LLM helpers ------------------------------------------------------
 

--- a/src/rath/llm/anthropic/client.py
+++ b/src/rath/llm/anthropic/client.py
@@ -62,6 +62,9 @@ def _config_provider_entry() -> Any:
     Returns ``None`` if the config file is absent, malformed, or has no
     ``provider_kind="anthropic"`` entry. Errors are swallowed by design —
     config is a fallback below explicit kwargs and env vars.
+
+    Since :meth:`ConfigStore.load` now caches by mtime, repeated calls are
+    effectively free (no disk re-read unless the file was modified).
     """
     try:
         from rath.config.store import ConfigStore

--- a/src/rath/llm/openai/client.py
+++ b/src/rath/llm/openai/client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from openai import (
     APIConnectionError,
@@ -57,6 +57,9 @@ def _config_provider_entry() -> Any:
     ``provider_kind="openai"`` entry. Errors are swallowed by design — the
     config file is a *fallback*, never a hard dependency. Lazy-imported so
     a vanilla ``import rath.llm`` does not touch the filesystem.
+
+    Since :meth:`ConfigStore.load` now caches by mtime, repeated calls are
+    effectively free (no disk re-read unless the file was modified).
     """
     try:
         from rath.config.store import ConfigStore
@@ -104,7 +107,7 @@ _STREAM_FINISH_REASONS = frozenset(
 
 def _coerce_stream_finish(value: Any) -> RathLLMFinishReason | None:
     if isinstance(value, str) and value in _STREAM_FINISH_REASONS:
-        return value  # type: ignore[return-value]
+        return cast(RathLLMFinishReason, value)
     return None
 
 

--- a/tests/config/test_store_caching.py
+++ b/tests/config/test_store_caching.py
@@ -1,0 +1,194 @@
+"""Tests for ``ConfigStore.load`` caching and ``save`` atomicity.
+
+These cover the perf path (``load()`` may return a cached instance when
+the underlying file has not changed) and the safety path (the cache key
+must invalidate when content changes even within one filesystem-mtime
+tick, which on HFS+ is 1 second).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from rath.config.paths import resolve_config_path
+from rath.config.schema import LLMProviderConfig
+from rath.config.store import ConfigStore
+
+
+@pytest.fixture(autouse=True)
+def _clear_class_cache() -> Iterator[None]:
+    """Cache is class-level state — clear before and after every test."""
+    ConfigStore._cache.clear()
+    yield
+    ConfigStore._cache.clear()
+
+
+def _seed_config_file(home: Path, api_key: str = "sk-initial") -> Path:
+    """Write a valid minimal config to the resolved OPENRATH_HOME path."""
+    path = resolve_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    store = ConfigStore(path=path)
+    store.config.llm.providers["main"] = LLMProviderConfig(
+        provider_kind="openai", model="gpt-5", api_key=api_key
+    )
+    store.config.llm.default_provider = "main"
+    store.save()
+    # ``save()`` invalidates the cache; reset state so callers begin
+    # from a known empty cache too.
+    ConfigStore._cache.clear()
+    return path
+
+
+def test_load_returns_cached_instance_when_unchanged(
+    _isolate_openrath_home: Path,
+) -> None:
+    _seed_config_file(_isolate_openrath_home)
+    first = ConfigStore.load()
+    second = ConfigStore.load()
+    assert second is first, (
+        "load() must return the same instance when the file hasn't "
+        "changed — otherwise the cache isn't doing its job"
+    )
+
+
+def test_save_invalidates_cache_for_next_load(
+    _isolate_openrath_home: Path,
+) -> None:
+    """In-process: after save(), the next load() must reflect the new data."""
+    _seed_config_file(_isolate_openrath_home, api_key="sk-v1")
+    first = ConfigStore.load()
+    assert first.config.llm.providers["main"].api_key == "sk-v1"
+
+    first.config.llm.providers["main"] = LLMProviderConfig(
+        provider_kind="openai", model="gpt-5", api_key="sk-v2"
+    )
+    first.save()
+
+    second = ConfigStore.load()
+    assert second.config.llm.providers["main"].api_key == "sk-v2"
+    # Cache invalidated → fresh instance returned (not the stale ``first``).
+    # NB: this is the contract; we don't assert ``is`` here because the
+    # rebuild may legitimately reuse identity in pathological cases.
+
+
+def test_load_rebuilds_when_file_mtime_changes(
+    _isolate_openrath_home: Path,
+) -> None:
+    """An out-of-band edit (mtime bump) must invalidate the cache."""
+    path = _seed_config_file(_isolate_openrath_home, api_key="sk-v1")
+    first = ConfigStore.load()
+
+    # Simulate an external editor rewriting the file with new content
+    # and a future mtime — bypasses ConfigStore.save() (and therefore
+    # the in-process cache invalidation), so the cache must invalidate
+    # itself based on the stamp.
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["llm"]["providers"]["main"]["api_key"] = "sk-external-edit"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    # Force a different mtime so the cache key differs even on coarse
+    # filesystems.
+    future = time.time() + 2.0
+    os.utime(path, (future, future))
+
+    second = ConfigStore.load()
+    assert second is not first
+    assert second.config.llm.providers["main"].api_key == "sk-external-edit"
+
+
+def test_same_mtime_but_different_size_invalidates_cache(
+    _isolate_openrath_home: Path,
+) -> None:
+    """Regression: on HFS+ (1-second mtime resolution), two writes within
+    the same second produce identical ``st_mtime_ns``. A mtime-only cache
+    key would return the **previous** content. ``ConfigStore`` keys on
+    ``(mtime_ns, size)`` so any rewrite that changes byte count is still
+    detected even when mtime ties.
+    """
+    path = _seed_config_file(_isolate_openrath_home, api_key="sk-short")
+    first = ConfigStore.load()
+    first_mtime = path.stat().st_mtime_ns
+
+    # Append-style rewrite: same mtime, different size.
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["llm"]["providers"]["main"]["api_key"] = (
+        "sk-much-longer-second-write-different-byte-count-xxxxxxxxxxxxx"
+    )
+    path.write_text(json.dumps(data), encoding="utf-8")
+    # Force the rewrite's mtime back to the original — simulates HFS+
+    # second-level resolution colliding within the same tick.
+    atime = path.stat().st_atime_ns
+    os.utime(path, ns=(atime, first_mtime))
+
+    assert path.stat().st_mtime_ns == first_mtime, "test setup did not pin mtime"
+    assert path.stat().st_size != len(
+        json.dumps(json.loads('{"llm":{"providers":{"main":{"api_key":"sk-short"}}}}'))
+    ), "rewrite did not actually change byte count"
+
+    second = ConfigStore.load()
+    assert second is not first, (
+        "size-changed rewrite must invalidate the cache even when mtime ties"
+    )
+    assert second.config.llm.providers["main"].api_key.startswith("sk-much-longer")
+
+
+def test_load_when_file_missing_does_not_cache(
+    _isolate_openrath_home: Path,
+) -> None:
+    """If the file doesn't exist, each load() returns a fresh default
+    instance (no cache key is meaningful for a non-existent file)."""
+    # No seeding — file doesn't exist.
+    first = ConfigStore.load()
+    second = ConfigStore.load()
+    assert first is not second, (
+        "non-existent file should not be cached; each load() rebuilds defaults"
+    )
+
+
+def test_concurrent_saves_dont_lose_data_or_leave_tmp(
+    _isolate_openrath_home: Path,
+) -> None:
+    """Atomic-save fix: two threads calling save() simultaneously must
+    each end up with a fully-written file (last writer wins) and leave
+    no ``.config_*.tmp`` debris in the config dir.
+    """
+    path = _seed_config_file(_isolate_openrath_home)
+
+    barrier = threading.Barrier(5)
+    errors: list[BaseException] = []
+
+    def _writer(tag: str) -> None:
+        try:
+            store = ConfigStore.load()
+            # Mutate to a tag-specific value so we can recognize last-writer
+            store.config.llm.providers["main"] = LLMProviderConfig(
+                provider_kind="openai", model="gpt-5", api_key=f"sk-{tag}"
+            )
+            barrier.wait(timeout=5.0)
+            store.save()
+        except BaseException as exc:  # noqa: BLE001 -- collected for assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_writer, args=(str(i),)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive()
+    assert not errors, f"concurrent save raised: {errors!r}"
+
+    # Final file is parseable and reflects ONE of the writers (last to
+    # ``replace()`` wins; we don't assert which).
+    final = json.loads(path.read_text(encoding="utf-8"))
+    final_key = final["llm"]["providers"]["main"]["api_key"]
+    assert final_key in {f"sk-{i}" for i in range(5)}
+
+    # No temp files left behind.
+    leftover_tmps = sorted(p.name for p in path.parent.glob(".config_*.tmp"))
+    assert leftover_tmps == [], f"atomic save left temp files: {leftover_tmps}"


### PR DESCRIPTION
## Summary

Addresses P1 performance issue: every `complete()` / `complete_stream()` call in OpenAI and Anthropic clients re-reads config from disk. A 20-turn conversation = 20+ redundant disk I/Os.

### Changes
- **Mtime-based cache**: `ConfigStore.load()` now caches parsed result + file mtime; subsequent calls check mtime first and return cached if unchanged
- **Atomic save fix**: Replaced fixed `.tmp` name with `tempfile.NamedTemporaryFile` for unique temp names — concurrent writers no longer corrupt each other
- **Thread safety**: Added `threading.Lock` on save operations

### Impact
OpenAI/Anthropic clients automatically benefit — `_config_provider_entry()` hits cache on all calls after the first.

### Tests
All existing tests pass (393 passed, 3 skipped).