### PR TITLE
perf(session): hoist immutable head + incremental tail rendering

### DIFF
--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -79,8 +79,11 @@ def run_session_compress(
 
     head = chunk_table_to_messages(agent_session.chunk_table)
     tail = chunk_table_to_messages(user_session.chunk_table)
+    # P2-fix: single unpack instead of two tuple concats.
     messages: tuple[RathLLMMessage, ...] = (
-        head + tail + (RathLLMMessage(role="user", content=instruction),)
+        *head,
+        *tail,
+        RathLLMMessage(role="user", content=instruction),
     )
 
     prefs = replace(agent_provider, tool_choice=None)

--- a/src/rath/session/loop.py
+++ b/src/rath/session/loop.py
@@ -47,6 +47,7 @@ from rath.llm import (
     RathLLMChatResponse,
     RathLLMFinishReason,
     RathLLMFunctionTool,
+    RathLLMMessage,
     RathLLMStreamDelta,
     RathLLMTokenUsage,
     RathLLMToolCallFunction,
@@ -248,7 +249,7 @@ def resolve_executor(
     return DefaultSessionLoopExecutor(client)
 
 
-def _sync_loop_out_rows(out: Session, rows_list: list[Any]) -> None:
+def _sync_loop_out_rows(out: Session, rows_list: list[ChunkRow]) -> None:
     out.chunk_table = ChunkTable(rows=tuple(rows_list))
 
 
@@ -446,7 +447,7 @@ def run_session_loop(
 
     prefs = agent_provider
 
-    rows_list: list[Any] = list(user_session.chunk_table.rows)
+    rows_list: list[ChunkRow] = list(user_session.chunk_table.rows)
     out = Session(
         chunk_table=ChunkTable(rows=tuple(rows_list)),
         sandbox_backend=user_session.sandbox_backend,
@@ -486,11 +487,21 @@ def run_session_loop(
     if not tool_schemas:
         tool_schemas = tools_dict_to_schemas(table)
 
+    # head is immutable after session start — compute once outside the loop.
+    head = chunk_table_to_messages(agent_session.chunk_table)
+    # Track how many rows have already been rendered into tail so we can
+    # incrementally extend rather than re-flatten every round.
+    _tail_rendered_up_to = 0
+    _tail_msgs: tuple[RathLLMMessage, ...] = ()
+
     try:
         for _ in range(max_tool_rounds):
-            head = chunk_table_to_messages(agent_session.chunk_table)
-            tail = chunk_table_to_messages(ChunkTable(rows=tuple(rows_list)))
-            messages = head + tail
+            # Incrementally extend tail with only new rows.
+            if len(rows_list) > _tail_rendered_up_to:
+                new_slice = ChunkTable(rows=tuple(rows_list[_tail_rendered_up_to:]))
+                _tail_msgs = _tail_msgs + chunk_table_to_messages(new_slice)
+                _tail_rendered_up_to = len(rows_list)
+            messages = head + _tail_msgs
 
             req = provider_into_chat_request(
                 messages,
@@ -588,7 +599,9 @@ def run_session_loop(
     if writer is not None:
         writer.close()
 
-    out.chunk_table = ChunkTable(rows=tuple(rows_list))
+    # Final sync covers the for/else exhaustion path; the normal break
+    # path already synced per-row above.
+    _sync_loop_out_rows(out, rows_list)
     reg.set_active(out)
     return out
 


### PR DESCRIPTION
## Summary

Two low-risk perf wins in ``run_session_loop`` and ``run_session_compress``. A third proposed optimization (batched ``ChunkTable`` rebuild) was dropped during self-review because it broke the ``chunk_print`` hook contract — see commit message for the full reasoning.

### Kept
- **Hoist immutable head** in ``run_session_loop``: ``chunk_table_to_messages(agent_session.chunk_table)`` is computed once before the loop instead of every round. The agent head is fixed at session construction.
- **Incremental tail rendering**: track ``_tail_rendered_up_to`` and extend ``_tail_msgs`` by the new slice each round. Total work O(rows) instead of O(rounds × rows).
- **``compress.py``**: single ``(*head, *tail, msg)`` unpack replaces two intermediate tuple concatenations.

### Dropped
- ~~Batched ``_sync_loop_out_rows`` (once per round instead of once per row)~~ — violated the documented invariant that ``out.chunk_table.rows[index]`` is readable inside ``chunk_print(row, index, out)``. Restored to per-row sync.

### Tests
- All existing session tests pass (80/80 in ``tests/session/``).
- New regression: ``test_chunk_print_sees_out_chunk_table_in_sync_with_index`` asserts the per-row sync contract directly (would fail against the batched version).
- Full suite: 395 passed / 48 skipped.