### PR TITLE
fix(flow/tool): serialize same-path filesystem operations

### DIFF
--- a/src/rath/flow/tool/system_tool.py
+++ b/src/rath/flow/tool/system_tool.py
@@ -97,11 +97,19 @@ def flow_tool_code_run(
     return session.require_sandbox().dispatch(call)
 
 
-def _path_resource_key(prefix: str, arguments: Mapping[str, Any]) -> tuple[str, ...]:
+# All filesystem tools share one resource-key namespace so that any mix of
+# operations on the SAME path (write+read, write+stat, ...) lands in one serial
+# lane and runs in transcript order. Distinct paths still fan out in parallel.
+# Using a per-operation prefix here (``fs:write`` vs ``fs:read``) would let a
+# write and a read of the same path run concurrently and race.
+_FS_RESOURCE_NAMESPACE = "fs"
+
+
+def _path_resource_key(arguments: Mapping[str, Any]) -> tuple[str, ...]:
     try:
-        return (prefix, str(arguments["path"]))
+        return (_FS_RESOURCE_NAMESPACE, str(arguments["path"]))
     except KeyError:
-        return (prefix, "<unknown>")
+        return (_FS_RESOURCE_NAMESPACE, "<unknown>")
 
 
 class FlowToolCommandRun(FlowToolCall):
@@ -154,7 +162,7 @@ class FlowToolFilesWrite(FlowToolCall):
     parallel_safe = True
 
     def resource_key(self, arguments: Mapping[str, Any]) -> tuple[str, ...]:
-        return _path_resource_key("fs:write", arguments)
+        return _path_resource_key(arguments)
 
     @property
     def name(self) -> str:
@@ -190,7 +198,7 @@ class FlowToolFilesRead(FlowToolCall):
     parallel_safe = True
 
     def resource_key(self, arguments: Mapping[str, Any]) -> tuple[str, ...]:
-        return _path_resource_key("fs:read", arguments)
+        return _path_resource_key(arguments)
 
     @property
     def name(self) -> str:
@@ -233,7 +241,7 @@ class FlowToolFilesList(FlowToolCall):
     parallel_safe = True
 
     def resource_key(self, arguments: Mapping[str, Any]) -> tuple[str, ...]:
-        return _path_resource_key("fs:list", arguments)
+        return _path_resource_key(arguments)
 
     @property
     def name(self) -> str:
@@ -264,7 +272,7 @@ class FlowToolFilesExists(FlowToolCall):
     parallel_safe = True
 
     def resource_key(self, arguments: Mapping[str, Any]) -> tuple[str, ...]:
-        return _path_resource_key("fs:stat", arguments)
+        return _path_resource_key(arguments)
 
     @property
     def name(self) -> str:

--- a/tests/unit/test_fs_resource_key.py
+++ b/tests/unit/test_fs_resource_key.py
@@ -1,0 +1,49 @@
+"""Filesystem tools must serialize on one resource-key per path.
+
+The async tool runner groups one round's tool calls into lanes keyed by
+:meth:`FlowToolCall.resource_key` and runs each lane sequentially while
+different lanes fan out concurrently. If read and write of the *same* path
+returned different keys they would land in different lanes and race, so a
+read could observe the file before or mid-write. These tests pin the
+contract: same path -> same key across every fs operation; different paths
+-> different keys.
+"""
+
+from __future__ import annotations
+
+from rath.flow.tool.system_tool import (
+    FlowToolFilesExists,
+    FlowToolFilesList,
+    FlowToolFilesRead,
+    FlowToolFilesWrite,
+)
+
+_FS_TOOLS = [
+    FlowToolFilesWrite(),
+    FlowToolFilesRead(),
+    FlowToolFilesList(),
+    FlowToolFilesExists(),
+]
+
+
+def test_same_path_shares_one_key_across_all_fs_ops() -> None:
+    keys = {tool.resource_key({"path": "/work/a.txt"}) for tool in _FS_TOOLS}
+    assert len(keys) == 1, f"fs ops on one path must share a lane, got {keys}"
+
+
+def test_write_and_read_same_path_serialize() -> None:
+    write_key = FlowToolFilesWrite().resource_key({"path": "/work/a.txt"})
+    read_key = FlowToolFilesRead().resource_key({"path": "/work/a.txt"})
+    assert write_key == read_key
+
+
+def test_distinct_paths_get_distinct_keys() -> None:
+    a = FlowToolFilesWrite().resource_key({"path": "/work/a.txt"})
+    b = FlowToolFilesWrite().resource_key({"path": "/work/b.txt"})
+    assert a != b
+
+
+def test_missing_path_is_handled() -> None:
+    # Falls back to a stable sentinel key rather than raising.
+    key = FlowToolFilesRead().resource_key({})
+    assert key[0] == "fs"


### PR DESCRIPTION
## Problem
The built-in file tools tag each operation with a per-operation resource key (`fs:write`, `fs:read`, `fs:list`, `fs:stat`). The session loop serializes tool calls that share a resource key and runs different keys concurrently. So a write and a read of the **same path** issued in one round ran in parallel and could race — the read may observe the file before or during the write, producing nondeterministic, silently-wrong results.

## Fix
Collapse all filesystem tools onto a single `("fs", path)` namespace. Any mix of operations on the same path now runs in transcript order, while distinct paths still fan out in parallel.

## Tests
`tests/unit/test_fs_resource_key.py`: same path → one shared key across write/read/list/exists; distinct paths → distinct keys. Full offline suite green; mypy + ruff clean.
