### PR TITLE
fix(session): hold sessions weakly in the global registry

### DIFF
--- a/src/rath/session/manager.py
+++ b/src/rath/session/manager.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from threading import Lock
 from uuid import UUID
+from weakref import WeakValueDictionary
 
 from rath.session.session import Session
 
 
 @dataclass
 class SessionRegistry:
-    """Maps session ids to instances and records which session is active."""
+    """Maps session ids to instances and records which session is active.
 
-    _by_id: dict[UUID, Session] = field(default_factory=dict)
+    The id->instance map holds **weak** references: a session is evicted
+    automatically once no other reference keeps it alive. Without this a
+    long-running process leaks every session (and its full transcript)
+    forever, since each loop registers three of them per turn and there is
+    no eviction path. ``get`` already returns ``None`` for absent ids, so a
+    collected session reads as "unknown", which is the intended contract.
+    """
+
+    _by_id: "WeakValueDictionary[UUID, Session]" = field(
+        default_factory=WeakValueDictionary
+    )
     _active_id: UUID | None = None
     _lock: Lock = field(default_factory=Lock)
 

--- a/tests/unit/test_session_registry_gc.py
+++ b/tests/unit/test_session_registry_gc.py
@@ -1,0 +1,52 @@
+"""The global session registry must not pin sessions forever.
+
+Each loop turn registers three sessions; with a plain dict and no eviction
+path a long-running process leaks every session and its full transcript.
+The registry holds weak references, so a session is collected once no other
+strong reference remains.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from rath.session import Session
+from rath.session.manager import SessionRegistry
+
+
+def test_registry_evicts_unreferenced_session() -> None:
+    reg = SessionRegistry()
+    session = Session.from_user_message("hi")
+    sid = session.id
+    reg.register(session)
+    assert reg.get(sid) is session
+
+    del session
+    gc.collect()
+
+    assert reg.get(sid) is None
+
+
+def test_registry_keeps_live_session() -> None:
+    reg = SessionRegistry()
+    session = Session.from_user_message("hi")
+    reg.register(session)
+    gc.collect()
+    # Still strongly referenced here -> must survive collection.
+    assert reg.get(session.id) is session
+
+
+def test_active_id_does_not_pin_session() -> None:
+    reg = SessionRegistry()
+    session = Session.from_user_message("hi")
+    sid = session.id
+    reg.register(session)
+    reg.set_active(session)
+
+    del session
+    gc.collect()
+
+    # The active *id* is retained (a UUID), but it must not keep the
+    # session instance alive.
+    assert reg.get_active_id() == sid
+    assert reg.get(sid) is None


### PR DESCRIPTION
## Problem
`SessionRegistry` stored sessions in a plain dict with no eviction path. Each loop turn registers three sessions, each pinning its full transcript, so a long-running process grows without bound.

## Fix
Back the id→instance map with a `WeakValueDictionary`; a session is evicted once no other reference holds it. `get()` already returns `None` for absent ids, so a collected session reads as "unknown", which is the intended contract.

## Tests
`tests/unit/test_session_registry_gc.py`: an unreferenced session is collected; a live session survives collection; the active *id* (a UUID) does not pin the instance. Full offline suite green; mypy + ruff clean.
