### PR TITLE
fix(session): lock lazy sandbox open to prevent double-open

### DIFF
--- a/src/rath/session/session.py
+++ b/src/rath/session/session.py
@@ -181,6 +181,7 @@ class Session:
         "_cumulative_usage",
         "_pending",
         "_sync_lock",
+        "_sandbox_lock",
         "__weakref__",
     )
 
@@ -216,6 +217,9 @@ class Session:
             None
         )
         self._sync_lock = threading.Lock()
+        # Serializes lazy sandbox open so parallel first-use tool calls cannot
+        # each open + acquire a backend sandbox and orphan all but the last.
+        self._sandbox_lock = threading.Lock()
 
     @property
     def chunk_table(self) -> ChunkTable:
@@ -376,19 +380,26 @@ class Session:
         return self
 
     def _ensure_sandbox(self) -> None:
+        # Fast path: already open. Re-check under the lock before opening so two
+        # parallel first-use tool calls cannot both open + acquire a backend
+        # sandbox (the loser of the race would be silently orphaned — an
+        # acquired handle, possibly a leaked remote container, never released).
         if self.sandbox is not None and not self.sandbox.closed:
             return
-        if self.sandbox is not None and self.sandbox.closed:
-            self.sandbox = None
-        if self.sandbox_backend is None:
-            raise RuntimeError(
-                'session has no sandbox backend; call session.to("local") '
-                "or session.bind_sandbox(...)"
-            )
-        open_spec = _coerce_sandbox_open_spec(self._sandbox_open_spec)
-        sb = get(self.sandbox_backend).open(open_spec)
-        sb.acquire()
-        self.sandbox = sb
+        with self._sandbox_lock:
+            if self.sandbox is not None and not self.sandbox.closed:
+                return
+            if self.sandbox is not None and self.sandbox.closed:
+                self.sandbox = None
+            if self.sandbox_backend is None:
+                raise RuntimeError(
+                    'session has no sandbox backend; call session.to("local") '
+                    "or session.bind_sandbox(...)"
+                )
+            open_spec = _coerce_sandbox_open_spec(self._sandbox_open_spec)
+            sb = get(self.sandbox_backend).open(open_spec)
+            sb.acquire()
+            self.sandbox = sb
 
     def __enter__(self) -> Session:
         if self._cm_depth == 0:

--- a/tests/unit/test_sandbox_lazy_open_race.py
+++ b/tests/unit/test_sandbox_lazy_open_race.py
@@ -1,0 +1,67 @@
+"""Lazy sandbox open must be race-free under parallel first-use tool calls.
+
+When several ``parallel_safe`` tools fire on the very first tool round, each
+calls ``require_sandbox()`` -> ``_ensure_sandbox()`` at once. Without a lock,
+two threads both pass the "is it open?" check, both open + acquire a backend
+sandbox, and the loser is silently orphaned (an acquired handle, never
+released). The double-checked lock guarantees exactly one open. A small sleep
+injected into the backend's ``open`` widens the race window so a regression
+(removing the lock) fails reliably rather than flaking green.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from rath.backend import get
+from rath.session import Session
+
+
+def test_concurrent_ensure_sandbox_opens_once(monkeypatch) -> None:
+    backend = get("local")
+    real_open = backend.open
+    n = 8
+    # All workers line up here, then enter _ensure_sandbox together.
+    barrier = threading.Barrier(n)
+
+    open_calls = 0
+    open_calls_lock = threading.Lock()
+
+    def slow_open(*args, **kwargs):
+        # Widen the open window so that, absent the lock, several threads
+        # would pass the "is it open?" check before the first assigns.
+        nonlocal open_calls
+        with open_calls_lock:
+            open_calls += 1
+        time.sleep(0.02)
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "open", slow_open)
+
+    session = Session.from_user_message("hi").to("local")
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=5)
+            session.require_sandbox()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    try:
+        assert not errors, f"require_sandbox raised under contention: {errors}"
+        # The lock must let exactly one thread open + acquire; the rest see the
+        # already-open handle. ``sandbox_count()`` is a process-global singleton
+        # counter (polluted by other tests), so assert on opens *we* caused.
+        assert open_calls == 1, f"expected one open, got {open_calls}"
+        assert session.sandbox is not None
+        assert session.sandbox.refcount == 1
+    finally:
+        session.close_sandbox()


### PR DESCRIPTION
## Problem
`_ensure_sandbox` checked whether the sandbox was open and then opened it with no lock. When two parallel first-use tool calls hit it together, both passed the check, both opened and acquired a backend sandbox, and the second assignment orphaned the first — an acquired handle (possibly a remote container) that is never released.

## Fix
Guard the open with a dedicated lock and re-check inside it (double-checked locking), so exactly one open happens and later callers see the already-open handle.

## Tests
`tests/unit/test_sandbox_lazy_open_race.py`: 8 threads enter `_ensure_sandbox` simultaneously; asserts exactly one backend open and refcount 1. Verified to fail (8 opens) when the lock is removed. Full offline suite green; mypy + ruff clean.
