### PR TITLE
fix(session): reject a summary truncated by the output limit

### DIFF
--- a/src/rath/session/compress.py
+++ b/src/rath/session/compress.py
@@ -158,7 +158,18 @@ def _completion_body(resp: RathLLMChatResponse) -> str | None:
             "run_session_compress: model returned tool calls but tools are disabled"
         )
     fr = choice.finish_reason
-    if fr not in ("stop", "length", "content_filter"):
+    if fr == "length":
+        # The summary REPLACES the entire prior transcript. A summary cut off by
+        # the output-token limit would silently drop the tail of the history
+        # with no signal, so refuse it rather than promote a truncated summary
+        # as the canonical replacement.
+        raise RuntimeError(
+            "run_session_compress: the summary hit the model output-token limit "
+            "(finish_reason='length') and is truncated; it would replace the "
+            "whole transcript and silently drop history. Retry with a larger "
+            "output-token budget."
+        )
+    if fr not in ("stop", "content_filter"):
         raise RuntimeError(f"run_session_compress: unexpected finish_reason={fr!r}")
     content = msg.content
     return None if content is None else str(content)

--- a/tests/unit/test_compress_truncation.py
+++ b/tests/unit/test_compress_truncation.py
@@ -1,0 +1,47 @@
+"""Compression must refuse a summary truncated by the output-token limit.
+
+The compressed summary REPLACES the entire prior transcript. A summary that
+hit the model's output cap (``finish_reason='length'``) is cut off, so
+accepting it would silently drop the tail of the history. The summary-body
+extractor raises instead, so the caller can retry with a larger budget.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rath.llm.chat_response import (
+    RathLLMAssistantMessage,
+    RathLLMChatChoice,
+    RathLLMChatResponse,
+)
+from rath.session.compress import _completion_body
+
+
+def _response(finish_reason: str, content: str | None) -> RathLLMChatResponse:
+    return RathLLMChatResponse(
+        id="",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason=finish_reason,  # type: ignore[arg-type]
+                message=RathLLMAssistantMessage(role="assistant", content=content),
+            ),
+        ),
+        created=0,
+        model="",
+        usage=None,
+    )
+
+
+def test_length_finish_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match="truncated"):
+        _completion_body(_response("length", "partial summary..."))
+
+
+def test_stop_finish_is_accepted() -> None:
+    assert _completion_body(_response("stop", "full summary")) == "full summary"
+
+
+def test_content_filter_finish_still_accepted() -> None:
+    assert _completion_body(_response("content_filter", "x")) == "x"


### PR DESCRIPTION
## Problem
`run_session_compress` replaces the entire prior transcript with the model's summary. It accepted `finish_reason="length"`, so a summary cut off by the output-token limit silently dropped the tail of the history with no signal — common when summarizing long histories with a small output cap.

## Fix
Raise a clear error on `finish_reason="length"`, telling the caller to retry with a larger output-token budget, instead of promoting a truncated summary as the canonical replacement.

## Tests
`tests/unit/test_compress_truncation.py`: `length` raises; `stop` and `content_filter` are still accepted. Full offline suite green; mypy + ruff clean.
