### PR TITLE
feat(session): add Session.text() and fix the Selector example

### DIFF
--- a/src/rath/session/session.py
+++ b/src/rath/session/session.py
@@ -248,6 +248,25 @@ class Session:
     def cumulative_usage(self, value: RathLLMTokenUsage | None) -> None:
         self._cumulative_usage = value
 
+    def text(self) -> str | None:
+        """Return the model's final answer: the last assistant message text.
+
+        Walks the transcript from the end and returns the ``content`` of the
+        most recent assistant chunk that carries non-empty text, skipping
+        assistant turns that are pure tool calls (``content is None``). Returns
+        ``None`` when the session holds no assistant text yet.
+
+        This is the most common thing a caller does after running a workflow;
+        reading ``chunk_table`` here blocks on lazy materialization as usual.
+        """
+        for row in reversed(self.chunk_table.rows):
+            if row.kind != ChunkKind.ASSISTANT:
+                continue
+            content = row.payload.get("content")
+            if content is not None and str(content).strip():
+                return str(content)
+        return None
+
     def synchronize(self) -> Session:
         """Block until ``_pending`` resolves; publish staged values; return self.
 

--- a/tests/session/test_example_selector_offline.py
+++ b/tests/session/test_example_selector_offline.py
@@ -1,0 +1,73 @@
+"""Offline smoke test for the dynamic-Selector example (example/11).
+
+The example previously crashed on its first run because it called
+``session.text()``, which did not exist. These tests exercise the same two
+patterns the example uses -- run an agent then read its answer, and route
+between self-describing workflows with a Selector -- against a scripted
+executor so they run with no live LLM and guard the marquee feature in CI.
+"""
+
+from __future__ import annotations
+
+from rath import flow
+from rath.llm import (
+    Provider,
+    RathLLMAssistantMessage,
+    RathLLMChatChoice,
+    RathLLMChatResponse,
+)
+from rath.session import Session
+from tests.session.scripted_loop_executor import ScriptedSessionLoopExecutor
+
+
+def _stop(content: str) -> RathLLMChatResponse:
+    return RathLLMChatResponse(
+        id="r",
+        choices=(
+            RathLLMChatChoice(
+                index=0,
+                finish_reason="stop",
+                message=RathLLMAssistantMessage(role="assistant", content=content),
+            ),
+        ),
+        created=0,
+        model="scripted",
+    )
+
+
+def test_agent_forward_then_text_returns_answer() -> None:
+    # Mirrors example/11: `session = chosen(session); print(session.text())`.
+    agent = flow.Agent("be brief", Provider(), description="answers things")
+    agent._executor_override = ScriptedSessionLoopExecutor([_stop("the answer")])
+
+    out = agent.forward(Session.from_user_message("question?"))
+
+    assert out.text() == "the answer"
+
+
+def test_selector_routes_to_chosen_workflow() -> None:
+    selector = flow.Selector(Provider())
+    # Scripted router reply "1" -> pick the second candidate.
+    selector._test_executor = ScriptedSessionLoopExecutor([_stop("1")])
+
+    billing = flow.Agent("billing", Provider(), description="billing questions")
+    tech = flow.Agent("tech", Provider(), description="technical questions")
+
+    chosen = selector.forward(
+        Session.from_user_message("my app crashes"), billing, tech
+    )
+
+    assert chosen is tech
+
+
+def test_selector_done_returns_empty_workflow() -> None:
+    selector = flow.Selector(Provider())
+    # Router reply "-1" -> nothing applies / task complete.
+    selector._test_executor = ScriptedSessionLoopExecutor([_stop("-1")])
+
+    billing = flow.Agent("billing", Provider(), description="billing questions")
+    tech = flow.Agent("tech", Provider(), description="technical questions")
+
+    chosen = selector.forward(Session.from_user_message("done now"), billing, tech)
+
+    assert isinstance(chosen, flow.EmptyWorkflow)

--- a/tests/unit/test_session_text.py
+++ b/tests/unit/test_session_text.py
@@ -1,0 +1,48 @@
+"""``Session.text()`` returns the model's final answer.
+
+This is the most common post-run operation; its absence is why the dynamic
+Selector example reached for a non-existent ``session.text()``. The accessor
+returns the last assistant message that carries text, skipping pure tool-call
+turns, and ``None`` when there is no assistant text yet.
+"""
+
+from __future__ import annotations
+
+from rath.session import Session
+from rath.session.chunk import (
+    ChunkTable,
+    assistant_turn_chunk,
+    user_text_chunk,
+)
+
+
+def _session(*rows: object) -> Session:
+    return Session(chunk_table=ChunkTable(rows=tuple(rows)))  # type: ignore[arg-type]
+
+
+def test_returns_last_assistant_text() -> None:
+    sess = _session(
+        user_text_chunk("hello"),
+        assistant_turn_chunk(tool_calls=None, content="first"),
+        user_text_chunk("more"),
+        assistant_turn_chunk(tool_calls=None, content="final answer"),
+    )
+    assert sess.text() == "final answer"
+
+
+def test_skips_trailing_pure_tool_call_turn() -> None:
+    sess = _session(
+        assistant_turn_chunk(tool_calls=None, content="the answer"),
+        # A pure tool-call turn (no text) must not mask the real answer.
+        assistant_turn_chunk(tool_calls=None, content=None),
+    )
+    assert sess.text() == "the answer"
+
+
+def test_none_when_no_assistant_text() -> None:
+    sess = _session(user_text_chunk("hi"))
+    assert sess.text() is None
+
+
+def test_empty_session_returns_none() -> None:
+    assert _session().text() is None


### PR DESCRIPTION
## Problem
There was no accessor for a session's final answer, so callers had to walk the raw transcript rows by hand. The dynamic-Selector example (`example/11_dynamic_selector.py`) already calls `session.text()`, which did not exist anywhere — so following the documented example crashes with `AttributeError` on first run.

## Fix
Add `Session.text()`, returning the `content` of the last assistant message that carries text (skipping pure tool-call turns), or `None` when there is no assistant text yet. The example now runs.

## Tests
`tests/unit/test_session_text.py`: last-answer / skip-trailing-tool-call / none / empty cases. `tests/session/test_example_selector_offline.py`: offline smoke test exercising the accessor and Selector routing with a scripted model, so this class of breakage fails CI. Full offline suite green; mypy + ruff clean.
