### PR TITLE
feat(session): add sequence protocol to ChunkTable and session ID to repr

### DIFF
--- a/src/rath/session/chunk.py
+++ b/src/rath/session/chunk.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
-from collections.abc import Iterator
 from typing import Any, Mapping, cast, overload
 
 from rath.llm import RathLLMMessage, RathLLMToolCallPart

--- a/src/rath/session/chunk.py
+++ b/src/rath/session/chunk.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Mapping, cast
+from collections.abc import Iterator
+from typing import Any, Mapping, cast, overload
 
 from rath.llm import RathLLMMessage, RathLLMToolCallPart
 
@@ -74,6 +75,19 @@ class ChunkTable:
     """Append-only chronological chunk list."""
 
     rows: tuple[ChunkRow, ...] = ()
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    @overload
+    def __getitem__(self, index: int) -> ChunkRow: ...
+    @overload
+    def __getitem__(self, index: slice) -> tuple[ChunkRow, ...]: ...
+    def __getitem__(self, index: int | slice) -> ChunkRow | tuple[ChunkRow, ...]:
+        return self.rows[index]
+
+    def __iter__(self) -> Iterator[ChunkRow]:
+        return iter(self.rows)
 
     def extend(self, *additional: ChunkRow) -> ChunkTable:
         return ChunkTable(rows=self.rows + tuple(additional))

--- a/src/rath/session/session.py
+++ b/src/rath/session/session.py
@@ -542,14 +542,15 @@ class Session:
 
     def __str__(self) -> str:
         cls_name = type(self).__name__
+        short_id = str(self.id).split("-", 1)[0]
         # Avoid triggering synchronize() in repr -- show pending state instead.
         if self._pending is not None:
-            return f"{cls_name}(pending …, operator={self.lineage_operator!r})"
+            return f"{cls_name}(id={short_id}, pending …, operator={self.lineage_operator!r})"
         block = _format_chunks_block(
             self._chunk_table.rows, edge=_SESSION_REPR_CHUNK_EDGE
         )
         return (
-            f"{cls_name}(\n  chunks={block},\n  operator={self.lineage_operator!r},\n)"
+            f"{cls_name}(id={short_id},\n  chunks={block},\n  operator={self.lineage_operator!r},\n)"
         )
 
     def __repr__(self) -> str:

--- a/src/rath/session/session.py
+++ b/src/rath/session/session.py
@@ -549,9 +549,7 @@ class Session:
         block = _format_chunks_block(
             self._chunk_table.rows, edge=_SESSION_REPR_CHUNK_EDGE
         )
-        return (
-            f"{cls_name}(id={short_id},\n  chunks={block},\n  operator={self.lineage_operator!r},\n)"
-        )
+        return f"{cls_name}(id={short_id},\n  chunks={block},\n  operator={self.lineage_operator!r},\n)"
 
     def __repr__(self) -> str:
         return self.__str__()


### PR DESCRIPTION
## Summary

- **ChunkTable** now implements `__len__`, `__getitem__`, and `__iter__`, making it a proper sequence type. This aligns with the PyTorch-like API philosophy — just as `Tensor` supports `len()`, indexing, and iteration, `ChunkTable` now does too:
  ```python
  # Before
  for row in session.chunk_table.rows: ...
  count = len(session.chunk_table.rows)

  # After
  for row in session.chunk_table: ...
  count = len(session.chunk_table)
  ```
- **Session.__repr__** now includes the first 8 hex chars of the session UUID, making it easier to track lineage in REPL and logs.