### PR TITLE
Feat/add litellm provider

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,12 @@ pretty = True
 # Heavy optional-SDK boundary: stubs and union returns lag behind runtime.
 ignore_errors = True
 
+[mypy-litellm]
+ignore_missing_imports = True
+
+[mypy-litellm.*]
+ignore_missing_imports = True
+
 [mypy-openviking]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Repository = "https://github.com/Rath-Team/OpenRath"
 
 [project.optional-dependencies]
 litellm = [
-    "litellm>=1.55.0,<2.0",
+    "litellm>=1.80,<1.88",
 ]
 opensandbox = [
     "opensandbox>=0.1.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ Repository = "https://github.com/Rath-Team/OpenRath"
 "Bug Tracker" = "https://github.com/Rath-Team/OpenRath/issues"
 
 [project.optional-dependencies]
+litellm = [
+    "litellm>=1.55.0,<2.0",
+]
 opensandbox = [
     "opensandbox>=0.1.7",
     "opensandbox-code-interpreter>=0.1.2",

--- a/src/rath/config/schema.py
+++ b/src/rath/config/schema.py
@@ -35,7 +35,7 @@ class LLMProviderConfig(BaseModel):
     to ``extra="allow"``.
     """
 
-    provider_kind: Literal["openai", "anthropic"] = "openai"
+    provider_kind: Literal["openai", "anthropic", "litellm"] = "openai"
     model: str | None = None
     api_key: str | None = None
     base_url: str | None = None

--- a/src/rath/llm/__init__.py
+++ b/src/rath/llm/__init__.py
@@ -23,6 +23,11 @@ from rath.llm.anthropic import (
     build_anthropic_stream_kwargs,
     normalize_anthropic_response,
 )
+
+try:
+    from rath.llm.litellm import RathLiteLLMChatClient
+except ImportError:
+    RathLiteLLMChatClient = None  # type: ignore[assignment,misc]
 from rath.llm.base import ChatClient, StreamingChatClient
 from rath.llm.budget import BudgetExceededError
 from rath.llm.chat_request import (
@@ -72,6 +77,7 @@ __all__ = [
     # Built-in adapters
     "RathOpenAIChatClient",
     "RathAnthropicChatClient",
+    "RathLiteLLMChatClient",
     # Embedding adapter (sync, OpenAI-compatible)
     "EmbeddingProvider",
     "RathOpenAIEmbeddingClient",

--- a/src/rath/llm/litellm/__init__.py
+++ b/src/rath/llm/litellm/__init__.py
@@ -1,0 +1,18 @@
+"""LiteLLM adapter for :class:`rath.llm.ChatClient`.
+
+Imports of this subpackage auto-register
+:class:`~rath.llm.litellm.client.RathLiteLLMChatClient` under
+``provider_kind="litellm"``.
+"""
+
+from __future__ import annotations
+
+from rath.llm.litellm.client import LITELLM_RETRYABLE, RathLiteLLMChatClient
+from rath.llm.registry import register_chat_client
+
+register_chat_client("litellm", RathLiteLLMChatClient)
+
+__all__ = [
+    "RathLiteLLMChatClient",
+    "LITELLM_RETRYABLE",
+]

--- a/src/rath/llm/litellm/client.py
+++ b/src/rath/llm/litellm/client.py
@@ -101,7 +101,7 @@ class RathLiteLLMChatClient:
 
         def _call() -> RathLLMChatResponse:
             response = litellm_completion(**kwargs)
-            return normalize_chat_completion(response)  # type: ignore[arg-type]
+            return normalize_chat_completion(response)
 
         return retry_with_backoff(
             _call,

--- a/src/rath/llm/litellm/client.py
+++ b/src/rath/llm/litellm/client.py
@@ -1,0 +1,134 @@
+"""Synchronous LiteLLM chat client (thin wrapper around ``litellm.completion``).
+
+LiteLLM provides a unified interface to 100+ LLM providers using the
+OpenAI completion format.  Because ``litellm.completion()`` returns
+OpenAI-compatible ``ModelResponse`` objects, this adapter reuses the
+OpenAI normalization and kwargs-building helpers from
+:mod:`rath.llm.openai`.
+
+Empty :attr:`Provider.api_key` falls back to ``LITELLM_API_KEY``;
+empty ``base_url`` falls back to ``LITELLM_API_BASE``.  When neither is
+set, LiteLLM resolves credentials from provider-specific environment
+variables (e.g. ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``) internally.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+from litellm import completion as litellm_completion
+from litellm.exceptions import (
+    APIConnectionError as _LiteLLMAPIConnectionError,
+)
+from litellm.exceptions import (
+    InternalServerError as _LiteLLMInternalServerError,
+)
+from litellm.exceptions import (
+    RateLimitError as _LiteLLMRateLimitError,
+)
+from litellm.exceptions import (
+    ServiceUnavailableError as _LiteLLMServiceUnavailableError,
+)
+from litellm.exceptions import (
+    Timeout as _LiteLLMTimeout,
+)
+
+from rath.llm.chat_request import RathLLMChatRequest
+from rath.llm.chat_response import RathLLMChatResponse, RathLLMStreamDelta
+from rath.llm.credentials import resolve_credential
+from rath.llm.openai.client import _chunk_to_deltas
+from rath.llm.openai.create_kwargs import to_create_kwargs, to_create_kwargs_stream
+from rath.llm.openai.normalize import normalize_chat_completion
+from rath.llm.provider import Provider
+from rath.llm.retry import retry_with_backoff
+
+LITELLM_RETRYABLE: tuple[type[BaseException], ...] = (
+    _LiteLLMRateLimitError,
+    _LiteLLMAPIConnectionError,
+    _LiteLLMTimeout,
+    _LiteLLMServiceUnavailableError,
+    _LiteLLMInternalServerError,
+)
+
+__all__ = ["RathLiteLLMChatClient", "LITELLM_RETRYABLE"]
+
+
+class RathLiteLLMChatClient:
+    """Thin client around ``litellm.completion`` (sync + streaming).
+
+    Model names use LiteLLM's provider-prefixed format
+    (e.g. ``anthropic/claude-sonnet-4-20250514``, ``gemini/gemini-2.0-flash``,
+    ``azure/gpt-4o``).  ``drop_params=True`` is always set so that
+    provider-unsupported kwargs are silently dropped instead of raising.
+    """
+
+    def __init__(self, provider: Provider) -> None:
+        key = resolve_credential(
+            provider.api_key,
+            os.environ.get("LITELLM_API_KEY"),
+        )
+        self._provider = provider
+        self._api_key = key or None
+        bu = resolve_credential(
+            provider.base_url,
+            os.environ.get("LITELLM_API_BASE"),
+        )
+        self._api_base = bu or None
+
+    @property
+    def provider(self) -> Provider:
+        return self._provider
+
+    def _inject_litellm_kwargs(self, kwargs: dict[str, Any]) -> None:
+        """Add LiteLLM-specific kwargs (drop_params, api_key, api_base)."""
+        kwargs["drop_params"] = True
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._api_base:
+            kwargs["api_base"] = self._api_base
+
+    def complete(self, req: RathLLMChatRequest) -> RathLLMChatResponse:
+        """Run ``litellm.completion`` and normalize the response.
+
+        Transient errors are retried per :attr:`Provider.retry_max_attempts` /
+        :attr:`Provider.retry_base_seconds`.
+        """
+        default_model = self._provider.model or os.environ.get("LITELLM_MODEL")
+        kwargs = to_create_kwargs(req, default_model=default_model)
+        self._inject_litellm_kwargs(kwargs)
+
+        def _call() -> RathLLMChatResponse:
+            response = litellm_completion(**kwargs)
+            return normalize_chat_completion(response)  # type: ignore[arg-type]
+
+        return retry_with_backoff(
+            _call,
+            retryable=LITELLM_RETRYABLE,
+            max_attempts=self._provider.retry_max_attempts,
+            base_seconds=self._provider.retry_base_seconds,
+        )
+
+    def complete_stream(self, req: RathLLMChatRequest) -> Iterator[RathLLMStreamDelta]:
+        """Yield ``RathLLMStreamDelta`` for each chunk of a streaming completion.
+
+        Transient errors during the initial ``litellm.completion`` call are
+        retried; once the iterator starts producing chunks, retries are no
+        longer possible.
+        """
+        default_model = self._provider.model or os.environ.get("LITELLM_MODEL")
+        kwargs = to_create_kwargs_stream(req, default_model=default_model)
+        self._inject_litellm_kwargs(kwargs)
+
+        def _open_stream() -> Any:
+            return litellm_completion(**kwargs)
+
+        stream = retry_with_backoff(
+            _open_stream,
+            retryable=LITELLM_RETRYABLE,
+            max_attempts=self._provider.retry_max_attempts,
+            base_seconds=self._provider.retry_base_seconds,
+        )
+        for chunk in stream:
+            yield from _chunk_to_deltas(chunk)

--- a/src/rath/llm/provider.py
+++ b/src/rath/llm/provider.py
@@ -68,7 +68,7 @@ class Provider:
     # Which adapter :func:`~rath.llm.registry.chat_client_for` constructs when
     # no custom executor is passed. ``None`` (default) selects OpenAI-compatible;
     # ``"anthropic"`` selects :class:`~rath.llm.RathAnthropicChatClient`.
-    provider_kind: Literal["openai", "anthropic"] | None = None
+    provider_kind: Literal["openai", "anthropic", "litellm"] | None = None
 
     def __str__(self) -> str:
         return self.model if self.model is not None else "(no model)"

--- a/tests/llm/test_litellm_client.py
+++ b/tests/llm/test_litellm_client.py
@@ -254,3 +254,389 @@ class TestCompleteStream:
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["drop_params"] is True
         assert call_kwargs["stream"] is True
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_stream_yields_deltas_from_chunks(
+        self, mock_completion: MagicMock
+    ) -> None:
+        chunk1 = MagicMock()
+        chunk1.model_dump.return_value = {
+            "id": "chatcmpl-stream",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "hel"},
+                    "finish_reason": None,
+                }
+            ],
+            "model": "openai/gpt-4o-mini",
+        }
+        chunk2 = MagicMock()
+        chunk2.model_dump.return_value = {
+            "id": "chatcmpl-stream",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "lo"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "model": "openai/gpt-4o-mini",
+        }
+        mock_completion.return_value = iter([chunk1, chunk2])
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        deltas = list(client.complete_stream(req))
+        assert len(deltas) >= 2
+        contents = [d.content_delta for d in deltas if d.content_delta]
+        assert "hel" in contents
+        assert "lo" in contents
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_stream_empty_chunks_handled(self, mock_completion: MagicMock) -> None:
+        empty_chunk = MagicMock()
+        empty_chunk.model_dump.return_value = {
+            "id": "chatcmpl-stream",
+            "choices": [],
+            "model": "openai/gpt-4o-mini",
+        }
+        mock_completion.return_value = iter([empty_chunk])
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        deltas = list(client.complete_stream(req))
+        assert isinstance(deltas, list)
+
+
+class TestExceptionHandling:
+    """Verify that litellm-specific exceptions propagate correctly."""
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_auth_error_propagates(self, mock_completion: MagicMock) -> None:
+        from litellm.exceptions import AuthenticationError
+
+        mock_completion.side_effect = AuthenticationError(
+            message="Invalid API key",
+            model="openai/gpt-4o-mini",
+            llm_provider="openai",
+        )
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                api_key="sk-invalid",
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        with pytest.raises(AuthenticationError):
+            client.complete(req)
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_not_found_error_propagates(self, mock_completion: MagicMock) -> None:
+        from litellm.exceptions import NotFoundError
+
+        mock_completion.side_effect = NotFoundError(
+            message="Model not found",
+            model="openai/nonexistent-model",
+            llm_provider="openai",
+        )
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/nonexistent-model",
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        with pytest.raises(NotFoundError):
+            client.complete(req)
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_rate_limit_is_retried(self, mock_completion: MagicMock) -> None:
+        from litellm.exceptions import RateLimitError
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+        mock_completion.side_effect = [
+            RateLimitError(
+                message="Rate limit exceeded",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+            mock_response,
+        ]
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                retry_max_attempts=2,
+                retry_base_seconds=0.0,
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        resp = client.complete(req)
+        assert resp.primary_choice.message.content == "ok"
+        assert mock_completion.call_count == 2
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_rate_limit_exhausts_retries(self, mock_completion: MagicMock) -> None:
+        from litellm.exceptions import RateLimitError
+
+        mock_completion.side_effect = RateLimitError(
+            message="Rate limit exceeded",
+            model="openai/gpt-4o-mini",
+            llm_provider="openai",
+        )
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                retry_max_attempts=2,
+                retry_base_seconds=0.0,
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        with pytest.raises(RateLimitError):
+            client.complete(req)
+        assert mock_completion.call_count == 2
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_timeout_is_retried(self, mock_completion: MagicMock) -> None:
+        from litellm.exceptions import Timeout
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "finally"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+        mock_completion.side_effect = [
+            Timeout(
+                message="Request timed out",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+            mock_response,
+        ]
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                retry_max_attempts=2,
+                retry_base_seconds=0.0,
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        resp = client.complete(req)
+        assert resp.primary_choice.message.content == "finally"
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_context_window_exceeded_propagates(
+        self, mock_completion: MagicMock
+    ) -> None:
+        from litellm.exceptions import ContextWindowExceededError
+
+        mock_completion.side_effect = ContextWindowExceededError(
+            message="Context window exceeded",
+            model="openai/gpt-4o-mini",
+            llm_provider="openai",
+        )
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="x" * 100000),),
+        )
+        with pytest.raises(ContextWindowExceededError):
+            client.complete(req)
+
+
+class TestMalformedResponses:
+    """Verify graceful handling of empty/null/malformed responses."""
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_empty_choices(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        resp = client.complete(req)
+        assert len(resp.choices) == 0
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_null_content_in_response(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": None},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        resp = client.complete(req)
+        assert resp.primary_choice.message.content is None
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_missing_usage_in_response(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        resp = client.complete(req)
+        assert resp.usage is None
+
+
+class TestModelStringFormat:
+    """Verify model strings are passed through correctly in provider-prefixed format."""
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_provider_prefixed_model_passed_through(
+        self, mock_completion: MagicMock
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "anthropic/claude-sonnet-4-20250514",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="anthropic/claude-sonnet-4-20250514",
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        client.complete(req)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-sonnet-4-20250514"
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_model_from_env_fallback(
+        self, mock_completion: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LITELLM_MODEL", "gemini/gemini-2.0-flash")
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "gemini/gemini-2.0-flash",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        client.complete(req)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["model"] == "gemini/gemini-2.0-flash"

--- a/tests/llm/test_litellm_client.py
+++ b/tests/llm/test_litellm_client.py
@@ -1,0 +1,256 @@
+"""Unit tests for :mod:`rath.llm.litellm` adapter."""
+
+from __future__ import annotations
+
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rath.llm import (
+    ChatClient,
+    Provider,
+    StreamingChatClient,
+    chat_client_for,
+    registered_kinds,
+)
+from rath.llm.chat_request import RathLLMChatRequest, RathLLMMessage
+from rath.llm.litellm import RathLiteLLMChatClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Ensure no stray env vars affect tests."""
+    for v in (
+        "LITELLM_API_KEY",
+        "LITELLM_API_BASE",
+        "LITELLM_MODEL",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    yield
+
+
+class TestRegistration:
+    def test_litellm_in_registered_kinds(self) -> None:
+        assert "litellm" in registered_kinds()
+
+    def test_chat_client_for_dispatches_litellm(self) -> None:
+        provider = Provider(provider_kind="litellm")
+        client = chat_client_for(provider)
+        assert isinstance(client, RathLiteLLMChatClient)
+
+
+class TestProtocols:
+    def test_litellm_client_is_chat_client(self) -> None:
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        assert isinstance(client, ChatClient)
+
+    def test_litellm_client_is_streaming(self) -> None:
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        assert isinstance(client, StreamingChatClient)
+
+
+class TestCredentialResolution:
+    def test_api_key_from_provider(self) -> None:
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", api_key="pk-test")
+        )
+        assert client._api_key == "pk-test"
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LITELLM_API_KEY", "env-key")
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        assert client._api_key == "env-key"
+
+    def test_provider_key_takes_precedence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LITELLM_API_KEY", "env-key")
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", api_key="provider-key")
+        )
+        assert client._api_key == "provider-key"
+
+    def test_no_key_is_none(self) -> None:
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        assert client._api_key is None
+
+    def test_base_url_from_provider(self) -> None:
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", base_url="http://localhost:4000")
+        )
+        assert client._api_base == "http://localhost:4000"
+
+    def test_base_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LITELLM_API_BASE", "http://proxy:4000")
+        client = RathLiteLLMChatClient(Provider(provider_kind="litellm"))
+        assert client._api_base == "http://proxy:4000"
+
+
+class TestComplete:
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_complete_passes_drop_params(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "hello"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "gpt-4o-mini",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        client.complete(req)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_complete_passes_api_key(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "total_tokens": 6,
+            },
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        client.complete(req)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test"
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_complete_passes_api_base(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "test-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "total_tokens": 6,
+            },
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(
+                provider_kind="litellm",
+                model="openai/gpt-4o-mini",
+                base_url="http://localhost:4000",
+            )
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        client.complete(req)
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["api_base"] == "http://localhost:4000"
+
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_complete_returns_normalized_response(
+        self, mock_completion: MagicMock
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "chatcmpl-123",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "pong",
+                    },
+                }
+            ],
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 1,
+                "total_tokens": 11,
+            },
+        }
+        mock_completion.return_value = mock_response
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="ping"),),
+        )
+        resp = client.complete(req)
+
+        assert resp.id == "chatcmpl-123"
+        assert resp.primary_choice.message.content == "pong"
+        assert resp.usage is not None
+        assert resp.usage.total_tokens == 11
+
+
+class TestCompleteStream:
+    @patch("rath.llm.litellm.client.litellm_completion")
+    def test_stream_passes_drop_params(self, mock_completion: MagicMock) -> None:
+        mock_completion.return_value = iter([])
+
+        client = RathLiteLLMChatClient(
+            Provider(provider_kind="litellm", model="openai/gpt-4o-mini")
+        )
+        req = RathLLMChatRequest(
+            messages=(RathLLMMessage(role="user", content="hi"),),
+        )
+        list(client.complete_stream(req))
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+        assert call_kwargs["stream"] is True

--- a/tests/llm/test_litellm_client.py
+++ b/tests/llm/test_litellm_client.py
@@ -15,7 +15,9 @@ from rath.llm import (
     registered_kinds,
 )
 from rath.llm.chat_request import RathLLMChatRequest, RathLLMMessage
-from rath.llm.litellm import RathLiteLLMChatClient
+
+pytest.importorskip("litellm")
+from rath.llm.litellm import RathLiteLLMChatClient  # noqa: E402  -- importorskip gated
 
 
 @pytest.fixture(autouse=True)
@@ -256,9 +258,7 @@ class TestCompleteStream:
         assert call_kwargs["stream"] is True
 
     @patch("rath.llm.litellm.client.litellm_completion")
-    def test_stream_yields_deltas_from_chunks(
-        self, mock_completion: MagicMock
-    ) -> None:
+    def test_stream_yields_deltas_from_chunks(self, mock_completion: MagicMock) -> None:
         chunk1 = MagicMock()
         chunk1.model_dump.return_value = {
             "id": "chatcmpl-stream",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1805,7 +1805,7 @@ wheels = [
 
 [[package]]
 name = "openrath"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1815,6 +1815,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+litellm = [
+    { name = "litellm" },
+]
 opensandbox = [
     { name = "opensandbox" },
     { name = "opensandbox-code-interpreter" },
@@ -1846,6 +1849,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80,<1.88" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opensandbox", marker = "extra == 'opensandbox'", specifier = ">=0.1.7" },
@@ -1854,7 +1858,7 @@ requires-dist = [
     { name = "openviking", marker = "extra == 'openviking'", specifier = ">=0.2.6" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
 ]
-provides-extras = ["opensandbox", "openviking"]
+provides-extras = ["litellm", "opensandbox", "openviking"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem

OpenRath supports two LLM providers (`openai` and `anthropic`). Using any other provider (Gemini, Bedrock, Azure, Ollama, Groq, etc.) requires manual client wiring outside the built-in `Provider` / `chat_client_for` dispatch.

## Proposal

Add a `litellm` provider kind that routes through [LiteLLM](https://github.com/BerriAI/litellm), giving OpenRath access to 100+ LLM providers via a single adapter. The new `RathLiteLLMChatClient` reuses OpenRath's existing OpenAI normalization and kwargs-building helpers since LiteLLM returns OpenAI-compatible responses.

Changes:
- New `src/rath/llm/litellm/` package with `RathLiteLLMChatClient` implementing `complete()` and `complete_stream()`
- Auto-registered via `register_chat_client("litellm", ...)` - dispatched by `chat_client_for()` when `provider_kind="litellm"`
- Added `"litellm"` to the `provider_kind` literal in `Provider` and `LLMProviderConfig`
- Lazy import with `ImportError` fallback in `rath.llm.__init__` - no impact when litellm is not installed
- Optional dep: `pip install openrath[litellm]`
- `drop_params=True` by default so provider-unsupported kwargs are silently dropped
- Credentials resolve from `Provider.api_key` / `Provider.base_url` first, then `LITELLM_API_KEY` / `LITELLM_API_BASE` env vars, then LiteLLM's own provider-specific env var resolution
- Retries use OpenRath's `retry_with_backoff` with LiteLLM-specific retryable exceptions (RateLimitError, Timeout, APIConnectionError, ServiceUnavailableError, InternalServerError)

Usage:

```python
from rath.llm import Provider, chat_client_for

provider = Provider(
    provider_kind="litellm",
    model="anthropic/claude-sonnet-4-20250514",
    api_key="sk-ant-...",
)
client = chat_client_for(provider)
resp = client.complete(req)
```

Or via config:

```yaml
llm:
  provider_kind: litellm
  model: gemini/gemini-2.0-flash
  # api_key resolved from GEMINI_API_KEY env var by LiteLLM
```

Backward compatible - defaults to `openai` when `provider_kind` is unset.

## Tests

`tests/llm/test_litellm_client.py` - 22 tests covering:
- Registration: `"litellm"` in `registered_kinds()`, `chat_client_for` dispatches correctly
- Protocols: client satisfies `ChatClient` and `StreamingChatClient` protocols
- Credential resolution: provider key vs env var precedence, base_url resolution, no-key-is-None
- `complete()`: passes `drop_params=True`, forwards `api_key`/`api_base`, returns normalized `RathLLMChatResponse`
