### PR TITLE
test(opensandbox): extend code-run timeout

### DIFF
--- a/tests/backends/test_opensandbox.py
+++ b/tests/backends/test_opensandbox.py
@@ -106,6 +106,7 @@ def test_unsupported_language_returns_failure() -> None:
         assert r.kind == "unsupported_tool"
 
 
+@pytest.mark.timeout(600)
 def test_code_run_python_round_trip() -> None:
     """Smoke that ``codes.run`` produces both stdout and a result text."""
     backend = get("opensandbox")


### PR DESCRIPTION
## Summary
- Give `test_code_run_python_round_trip` a targeted 600s timeout instead of changing all OpenSandbox tests.
- Keeps the broader OpenSandbox marker timeout unchanged.

## Verification
- `uv run ruff check tests/backends/test_opensandbox.py`
- `uv run ruff format --check tests/backends/test_opensandbox.py`
- `git diff --check`
- `uv run pytest tests/backends/test_opensandbox.py::test_code_run_python_round_trip -q` (skipped locally because no OpenSandbox server is running)