### PR TITLE
fix(backend/persistence): round-trip empty entrypoint/env in spec_json

### DIFF
--- a/src/rath/backend/persistence/spec_json.py
+++ b/src/rath/backend/persistence/spec_json.py
@@ -42,10 +42,12 @@ def spec_from_jsonable(raw: dict[str, Any] | None) -> BackendSandboxSpec | None:
     if raw is None:
         return None
     timeout_s = raw.get("timeout_seconds")
+    entrypoint = raw.get("entrypoint")
+    env = raw.get("env")
     return BackendSandboxSpec(
         image=raw.get("image"),
-        entrypoint=tuple(raw["entrypoint"]) if raw.get("entrypoint") else None,
-        env=dict(raw["env"]) if raw.get("env") else None,
+        entrypoint=tuple(entrypoint) if entrypoint is not None else None,
+        env=dict(env) if env is not None else None,
         timeout=timedelta(seconds=float(timeout_s)) if timeout_s is not None else None,
         working_dir=raw.get("working_dir"),
     )

--- a/tests/backends/persistence/test_spec_json.py
+++ b/tests/backends/persistence/test_spec_json.py
@@ -1,0 +1,58 @@
+"""Round-trip fidelity for :mod:`rath.backend.persistence.spec_json`.
+
+``spec_to_jsonable`` preserves the ``None``-vs-empty distinction, so
+``spec_from_jsonable`` must too: an empty ``entrypoint`` / ``env`` should
+survive the round trip as an empty collection rather than collapsing to
+``None``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from rath.backend.abc import BackendSandboxSpec
+from rath.backend.persistence.spec_json import spec_from_jsonable, spec_to_jsonable
+
+
+def test_none_spec_round_trips() -> None:
+    assert spec_to_jsonable(None) is None
+    assert spec_from_jsonable(None) is None
+
+
+def test_full_spec_round_trips() -> None:
+    spec = BackendSandboxSpec(
+        image="python:3.12",
+        entrypoint=("bash", "-lc"),
+        env={"K": "V", "N": "1"},
+        timeout=timedelta(seconds=30),
+        working_dir="/ws",
+    )
+    back = spec_from_jsonable(spec_to_jsonable(spec))
+    assert back == spec
+
+
+def test_empty_entrypoint_and_env_survive_round_trip() -> None:
+    """Empty collections must stay empty, not decay to ``None``."""
+    spec = BackendSandboxSpec(entrypoint=(), env={})
+    back = spec_from_jsonable(spec_to_jsonable(spec))
+    assert back is not None
+    assert back.entrypoint == ()
+    assert back.env == {}
+
+
+def test_unset_fields_stay_none() -> None:
+    spec = BackendSandboxSpec()
+    back = spec_from_jsonable(spec_to_jsonable(spec))
+    assert back == spec
+    assert back is not None
+    assert back.entrypoint is None
+    assert back.env is None
+    assert back.timeout is None
+
+
+def test_zero_timeout_round_trips() -> None:
+    """A zero timedelta is distinct from an unset timeout and must be kept."""
+    spec = BackendSandboxSpec(timeout=timedelta(0))
+    back = spec_from_jsonable(spec_to_jsonable(spec))
+    assert back is not None
+    assert back.timeout == timedelta(0)


### PR DESCRIPTION
## Motivation

`spec_to_jsonable` / `spec_from_jsonable` are the JSONable round-trip for `BackendSandboxSpec`, shared by the on-disk backend registry (`rath.backend.persistence.registry`) and the session writer/loader (`rath.session.persistence`). The two halves disagree about empty collections:

- `spec_to_jsonable` preserves the `None`-vs-empty distinction: `entrypoint=()` serializes to `[]`, `env={}` to `{}` (guarded by `is not None`).
- `spec_from_jsonable` rebuilt those fields with **truthiness** checks (`if raw.get("entrypoint")`), so an empty `[]` / `{}` decayed back to `None` on load.

So a `BackendSandboxSpec(env={})` silently becomes `env=None` after a persist/reload cycle — a lossy round trip for both persisted formats.

## What changed

- `spec_from_jsonable`: rebuild `entrypoint` / `env` with `is not None` instead of truthiness, mirroring the serializer. Empty collections now survive the round trip.
- Added `tests/backends/persistence/test_spec_json.py` with offline round-trip coverage (None spec, full spec, empty-collection, unset-stays-None, zero-timeout). The module previously had no dedicated test.

## How I verified

```
uv run ruff check src tests example      # All checks passed
uv run ruff format --check src tests example
uv run mypy src                          # Success: no issues found in 105 source files
uv run pytest tests/backends/persistence/test_spec_json.py -q   # 5 passed
```

No behavior change beyond the fixed round-trip; no public API surface change.