### PR TITLE
fix(flow): warn on best-effort Agent memory failures

### DIFF
--- a/src/rath/flow/agent.py
+++ b/src/rath/flow/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import replace
 from typing import Union
@@ -16,6 +17,8 @@ from rath.memory.abc import MemoryStore, MemoryStoreSpec
 from rath.session import Session, run_session_loop
 
 MemoryArg = Union[MemoryStore, MemoryStoreSpec, str, None]
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_memory(memory: MemoryArg) -> MemoryStore | None:
@@ -132,7 +135,12 @@ class Agent(Workflow):
         assert self.memory is not None  # caller-checked
         try:
             extras = self._memory_inject.inject(session, self.memory)
-        except Exception:  # noqa: BLE001 -- recall must not break the loop
+        except Exception as exc:  # noqa: BLE001 -- recall must not break the loop
+            logger.warning(
+                "memory injection failed; continuing without recalled memory: %s",
+                exc,
+                exc_info=True,
+            )
             extras = ()
         if not extras:
             return session
@@ -175,8 +183,12 @@ class Agent(Workflow):
                     wait=wait,
                 )
             )
-        except Exception:  # noqa: BLE001 -- commit must not break forward
-            pass
+        except Exception as exc:  # noqa: BLE001 -- commit must not break forward
+            logger.warning(
+                "memory commit failed; continuing without persisted memory: %s",
+                exc,
+                exc_info=True,
+            )
 
     # ---------------------------------------------------------------- public memory API
 

--- a/tests/flow/test_agent_forward_memory.py
+++ b/tests/flow/test_agent_forward_memory.py
@@ -8,6 +8,7 @@ subset Agent uses (``MemoryOpFind`` and ``MemoryOpCommit``).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 import pytest
@@ -25,7 +26,7 @@ from rath.memory.results import (
     MemoryResult,
 )
 from rath.session import Session, session_registry
-from rath.session.chunk import ChunkKind
+from rath.session.chunk import ChunkKind, ChunkRow
 from tests.session.scripted_loop_executor import ScriptedSessionLoopExecutor
 
 
@@ -38,6 +39,7 @@ def _clear_active_session_registry() -> None:
 @dataclass
 class _FakeBackend(MemoryBackend):
     find_hits: tuple[MemoryHit, ...] = ()
+    commit_error: Exception | None = None
     ops_seen: list[MemoryOp] = field(default_factory=list)
 
     @classmethod
@@ -77,10 +79,17 @@ class _FakeBackend(MemoryBackend):
         if isinstance(op, MemoryOpFind):
             return MemoryFindResult(hits=self.find_hits)
         if isinstance(op, MemoryOpCommit):
+            if self.commit_error is not None:
+                raise self.commit_error
             return MemoryCommitResult(
                 task_id="task-x", archived_uri="memory://session/s/", extracted_count=-1
             )
         raise NotImplementedError(f"fake: no handler for {type(op).__name__}")
+
+
+class _FailingInjection:
+    def inject(self, session: Session, store: object) -> tuple[ChunkRow, ...]:
+        raise RuntimeError("recall exploded")
 
 
 def _scripted_response(text: str) -> RathLLMChatResponse:
@@ -178,3 +187,53 @@ def test_forward_without_commit_does_not_dispatch_commit() -> None:
     sess = Session.from_user_message("nothing important")
     agent.forward(sess)
     assert not any(isinstance(op, MemoryOpCommit) for op in backend.ops_seen)
+
+
+def test_forward_logs_warning_when_memory_injection_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    backend = _FakeBackend(find_hits=())
+    store = backend.open()
+    exec_ = ScriptedSessionLoopExecutor([_scripted_response("ack")])
+    agent = Agent(
+        "system",
+        model="gpt-5.5",
+        memory=store,
+        memory_inject=_FailingInjection(),
+    )
+    agent._executor_override = exec_
+    sess = Session.from_user_message("remember me")
+
+    with caplog.at_level(logging.WARNING, logger="rath.flow.agent"):
+        out = agent.forward(sess)
+
+    assert out.text() == "ack"
+    assert any(
+        "memory injection failed" in rec.getMessage() and rec.exc_info
+        for rec in caplog.records
+    )
+
+
+def test_forward_logs_warning_when_auto_commit_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    backend = _FakeBackend(find_hits=(), commit_error=RuntimeError("commit exploded"))
+    store = backend.open()
+    exec_ = ScriptedSessionLoopExecutor([_scripted_response("ack")])
+    agent = Agent(
+        "system",
+        model="gpt-5.5",
+        memory=store,
+        commit_on_forward=True,
+    )
+    agent._executor_override = exec_
+    sess = Session.from_user_message("remember me")
+
+    with caplog.at_level(logging.WARNING, logger="rath.flow.agent"):
+        out = agent.forward(sess)
+
+    assert out.text() == "ack"
+    assert any(
+        "memory commit failed" in rec.getMessage() and rec.exc_info
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary

This PR makes best-effort `Agent` memory failures observable without changing
`Agent.forward()` execution behavior.

Previously, `Agent` silently swallowed exceptions from:

- memory injection
- `commit_on_forward` memory commit

Both paths still continue as before, but now emit warnings with traceback so
users can diagnose skipped memory recall or persistence failures.

## Why

Other recoverable/degraded paths in OpenRath already log warnings when work is
skipped or downgraded, for example:

- memory injection skips closed stores or failed dispatches
- session loop warns when token budget is exceeded without a callback
- config warns on unsafe secret-file permissions
- backend persistence skips malformed records with warnings
- OpenSandbox logs workspace-bind fallback before retrying

This change keeps `Agent` memory handling aligned with that existing local
convention. It does not introduce a new logging policy or change logging
configuration.

## Behavior

Before:

- memory injection failure: swallowed silently
- `commit_on_forward` failure: swallowed silently

After:

- memory injection failure: warning logged, forward continues
- `commit_on_forward` failure: warning logged, forward continues

## Follow-up consideration

This repository may benefit from a future, maintainer-led logging policy that
defines logging levels and context conventions across modules, such as:

- when to use `debug`, `info`, `warning`, or `exception`
- which recoverable failures should include `exc_info`
- whether session/backend/memory identifiers should be included consistently
- whether structured logging or correlation IDs are desirable for multi-session
  workflows

This PR intentionally stays narrower and only fills two silent best-effort
failure paths.

## Tests

- `uv run pytest tests/flow/test_agent_forward_memory.py tests/flow/test_memory_inject.py -q -p no:cacheprovider`
- `uv run ruff check src/rath/flow/agent.py tests/flow/test_agent_forward_memory.py`
- `uv run ruff format --check src/rath/flow/agent.py tests/flow/test_agent_forward_memory.py`
- `uv run mypy --no-incremental`