### PR TITLE
fix(memory): guard MemoryStore refcount updates

### DIFF
--- a/src/rath/memory/abc.py
+++ b/src/rath/memory/abc.py
@@ -9,6 +9,7 @@ mirrors :class:`~rath.backend.abc.Backend`.
 
 from __future__ import annotations
 
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -101,25 +102,34 @@ class MemoryStore:
     spec: MemoryStoreSpec | None = None
     closed: bool = field(default=False)
     _refcount: int = field(default=0, repr=False)
+    # Match ``BackendSandbox`` lifecycle locking: serialize refcount updates,
+    # then let ``release`` call ``backend.close`` outside the lock.
+    _refcount_lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
 
     @property
     def refcount(self) -> int:
         """Current number of live references; read-only mirror of internal state."""
-        return self._refcount
+        with self._refcount_lock:
+            return self._refcount
 
     def acquire(self) -> "MemoryStore":
         """Add one reference; return ``self`` for chaining."""
-        if self.closed:
-            raise MemoryStoreClosed(self.handle)
-        self._refcount += 1
+        with self._refcount_lock:
+            if self.closed:
+                raise MemoryStoreClosed(self.handle)
+            self._refcount += 1
         return self
 
     def release(self) -> None:
         """Drop one reference; close via the backend when the count hits zero."""
-        if self.closed:
-            return
-        self._refcount -= 1
-        if self._refcount <= 0:
+        with self._refcount_lock:
+            if self.closed:
+                return
+            self._refcount -= 1
+            should_close = self._refcount <= 0
+        if should_close:
             self.backend.close(self)
 
     def __enter__(self) -> "MemoryStore":

--- a/tests/memory/unit/test_store_refcount.py
+++ b/tests/memory/unit/test_store_refcount.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+import time
+
 import pytest
 
 from rath.memory.abc import MemoryStore, MemoryStoreSpec
@@ -20,6 +23,38 @@ class _FakeBackend:
     def close(self, store: MemoryStore) -> None:
         self.close_calls.append(store)
         store.closed = True
+
+
+class _YieldingRefcount:
+    """Refcount test double that makes read/modify/write races deterministic."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __iadd__(self, amount: int) -> "_YieldingRefcount":
+        current = self.value
+        time.sleep(0.01)
+        self.value = current + amount
+        return self
+
+    def __isub__(self, amount: int) -> "_YieldingRefcount":
+        current = self.value
+        time.sleep(0.01)
+        self.value = current - amount
+        return self
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, int):
+            return NotImplemented
+        return self.value <= other
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, int):
+            return NotImplemented
+        return self.value == other
+
+    def __repr__(self) -> str:
+        return repr(self.value)
 
 
 def _make_store(backend: _FakeBackend | None = None) -> MemoryStore:
@@ -83,6 +118,53 @@ def test_nested_context_manager_tracks_refcount():
         assert fake.close_calls == []
     assert store.refcount == 0
     assert fake.close_calls == [store]
+
+
+def test_concurrent_acquire_release_is_safe():
+    """Hammer acquire/release from many threads; refcount must stay coherent."""
+    fake = _FakeBackend()
+    store = _make_store(fake)
+    store.acquire()  # baseline ref so the count cannot drain to zero mid-test
+
+    threads = 8
+    iters = 1000
+
+    def worker() -> None:
+        for _ in range(iters):
+            store.acquire()
+            store.release()
+
+    workers = [threading.Thread(target=worker) for _ in range(threads)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join()
+
+    assert store.refcount == 1
+    assert store.closed is False
+    assert fake.close_calls == []
+    store.release()
+    assert store.closed is True
+    assert fake.close_calls == [store]
+
+
+def test_concurrent_acquire_serializes_refcount_mutation():
+    store = _make_store()
+    store._refcount = _YieldingRefcount(1)  # type: ignore[assignment]
+    ready = threading.Barrier(3)
+
+    def worker() -> None:
+        ready.wait()
+        store.acquire()
+
+    workers = [threading.Thread(target=worker) for _ in range(2)]
+    for t in workers:
+        t.start()
+    ready.wait()
+    for t in workers:
+        t.join()
+
+    assert store.refcount == 3
 
 
 def test_acquire_after_close_raises_memory_store_closed():


### PR DESCRIPTION
﻿## Summary

This PR guards `MemoryStore` refcount reads and writes with a lock, matching the lifecycle pattern already used by `BackendSandbox`.

`MemoryStore` is documented as mirroring `BackendSandbox` lifecycle semantics, but its `_refcount` was previously updated without synchronization. This could lose updates when the same store is acquired or released concurrently.

## Why

`MemoryStore` can be shared across holders:

- an already-open store can be passed into `Agent(memory=store)`
- `Agent` acquires the store during initialization
- `Agent.close()` releases the store
- callers may also use explicit `store.acquire()` / `store.release()` or `with store:`

`BackendSandbox`, the parallel refcounted handle, already protects `_refcount` with `threading.Lock` and has a concurrency test for acquire/release behavior. This PR aligns `MemoryStore` with that existing pattern without changing close-on-zero semantics.

## Behavior

Before:

- concurrent `MemoryStore.acquire()` / `release()` could race on `_refcount`
- read/modify/write updates were not serialized

After:

- `refcount`, `acquire()`, and `release()` use `_refcount_lock`
- close still happens outside the lock, following the `BackendSandbox` pattern
- public lifecycle behavior remains unchanged

## Tests

Added memory refcount coverage for:

- concurrent acquire/release stress behavior
- deterministic lost-update reproduction using a yielding refcount test double

Verification run:

- `uv run pytest tests/memory/unit/test_store_refcount.py tests/flow/test_agent_memory_lifecycle.py tests/flow/test_agent_memory_init.py -q -p no:cacheprovider`
- `uv run pytest tests/memory/unit -q -p no:cacheprovider`
- `uv run ruff check src/rath/memory/abc.py tests/memory/unit/test_store_refcount.py`
- `uv run ruff format --check src/rath/memory/abc.py tests/memory/unit/test_store_refcount.py`
- `uv run mypy --no-incremental`

## Notes

This PR only protects the `MemoryStore` lifecycle counter. Not claiming that every memory backend operation is thread-safe.
